### PR TITLE
Add Year to Date (YTD) overview section to home page

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/ytd-overview.tsx
+++ b/src/components/ytd-overview.tsx
@@ -46,8 +46,8 @@ export function YTDOverview({ compact = false }: YTDOverviewProps) {
       })
       .reduce((total, income) => total + (income.amount || 0), 0)
 
-    // YTD Spent: All expenses from Jan 1 to current month of current year
-    const ytdSpent = expenses
+    // YTD Expenses: All expenses from Jan 1 to current month of current year
+    const ytdExpenses = expenses
       .filter((expense) => {
         const expenseDate = new Date(expense.date)
         return (
@@ -56,6 +56,20 @@ export function YTDOverview({ compact = false }: YTDOverviewProps) {
         )
       })
       .reduce((total, expense) => total + (expense.amount || 0), 0)
+
+    // YTD Investment Contributions (to exclude from spent)
+    const ytdInvestmentContributions = investmentContributions
+      .filter((contribution) => {
+        const contributionDate = new Date(contribution.date)
+        return (
+          contributionDate.getFullYear() === currentYear &&
+          contributionDate.getMonth() <= currentMonth
+        )
+      })
+      .reduce((total, contribution) => total + (contribution.amount || 0), 0)
+
+    // YTD Spent: Expenses minus investments (money moved to investments isn't "spent")
+    const ytdSpent = ytdExpenses - ytdInvestmentContributions
 
     // YTD Budget: Sum of all non-archived category monthly budgets × (current month + 1)
     const monthsElapsed = currentMonth + 1

--- a/src/components/ytd-overview.tsx
+++ b/src/components/ytd-overview.tsx
@@ -2,12 +2,29 @@
 
 import { useMemo } from 'react'
 import { Calendar, CreditCard, DollarSign, PiggyBank, TrendingUp, Wallet, BarChart2 } from 'lucide-react'
-import { SimpleGrid, Title, Stack } from '@mantine/core'
+import { SimpleGrid, Title, Stack, Card, Group, Text, Box } from '@mantine/core'
 import { OverviewCard } from '@/components/overview-card'
 import { useCategoryStore, useExpenseStore, useIncomeStore } from '@/stores/instantdb'
 import { useInvestmentStore } from '@/stores/useInvestmentStore'
 
-export function YTDOverview() {
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
+})
+
+const percentFormatter = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1
+})
+
+interface YTDOverviewProps {
+  compact?: boolean
+}
+
+export function YTDOverview({ compact = false }: YTDOverviewProps) {
   const currentDate = new Date()
   const currentYear = currentDate.getFullYear()
   const currentMonth = currentDate.getMonth() // 0-indexed
@@ -64,7 +81,7 @@ export function YTDOverview() {
     const ytdSavings = ytdIncome - ytdSpent
 
     // YTD Savings Rate
-    const ytdSavingsRate = ytdIncome > 0 ? (ytdSavings / ytdIncome) * 100 : 0
+    const ytdSavingsRate = ytdIncome > 0 ? ytdSavings / ytdIncome : 0
 
     return {
       ytdIncome,
@@ -87,9 +104,40 @@ export function YTDOverview() {
   ])
 
   const formatCurrency = (amount: number): string => {
-    return `$${amount.toFixed(2)}`
+    return currencyFormatter.format(amount)
   }
 
+  const formatPercent = (value: number): string => {
+    return percentFormatter.format(value)
+  }
+
+  const metrics = [
+    { label: 'YTD Budget', value: formatCurrency(ytdData.ytdBudget) },
+    { label: 'YTD Spent', value: formatCurrency(ytdData.ytdSpent) },
+    { label: 'YTD Income', value: formatCurrency(ytdData.ytdIncome) },
+    { label: 'Total Invested', value: formatCurrency(ytdData.totalInvested) },
+    { label: 'Investment Value', value: formatCurrency(ytdData.totalInvestmentValue) },
+    { label: 'YTD Savings', value: formatCurrency(ytdData.ytdSavings) },
+    { label: 'Savings Rate', value: formatPercent(ytdData.ytdSavingsRate) }
+  ]
+
+  // Compact view: single card with key-value pairs (for mobile)
+  if (compact) {
+    return (
+      <Card shadow="sm" padding="md" radius="md" withBorder>
+        <Stack gap="xs">
+          {metrics.map((metric) => (
+            <Group key={metric.label} justify="space-between">
+              <Text size="sm" c="dimmed">{metric.label}</Text>
+              <Text size="sm" fw={600} className="numeric-value">{metric.value}</Text>
+            </Group>
+          ))}
+        </Stack>
+      </Card>
+    )
+  }
+
+  // Full view: cards with icons (for desktop)
   return (
     <Stack gap="sm">
       <Title order={4} c="dimmed">
@@ -129,7 +177,7 @@ export function YTDOverview() {
         />
         <OverviewCard
           title="Savings Rate"
-          value={`${ytdData.ytdSavingsRate.toFixed(1)}%`}
+          value={formatPercent(ytdData.ytdSavingsRate)}
           icon={<BarChart2 size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
         />
       </SimpleGrid>

--- a/src/components/ytd-overview.tsx
+++ b/src/components/ytd-overview.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react'
 import { Calendar, CreditCard, DollarSign, PiggyBank, TrendingUp, Wallet, BarChart2 } from 'lucide-react'
-import { SimpleGrid, Title, Stack, Card, Group, Text, Box } from '@mantine/core'
+import { SimpleGrid, Title, Stack, Group, Text } from '@mantine/core'
 import { OverviewCard } from '@/components/overview-card'
 import { useCategoryStore, useExpenseStore, useIncomeStore } from '@/stores/instantdb'
 import { useInvestmentStore } from '@/stores/useInvestmentStore'
@@ -135,19 +135,17 @@ export function YTDOverview({ compact = false }: YTDOverviewProps) {
     { label: 'Savings Rate', value: formatPercent(ytdData.ytdSavingsRate) }
   ]
 
-  // Compact view: single card with key-value pairs (for mobile)
+  // Compact view: key-value pairs without card wrapper (for mobile accordion)
   if (compact) {
     return (
-      <Card shadow="sm" padding="md" radius="md" withBorder>
-        <Stack gap="xs">
-          {metrics.map((metric) => (
-            <Group key={metric.label} justify="space-between">
-              <Text size="sm" c="dimmed">{metric.label}</Text>
-              <Text size="sm" fw={600} className="numeric-value">{metric.value}</Text>
-            </Group>
-          ))}
-        </Stack>
-      </Card>
+      <Stack gap="xs">
+        {metrics.map((metric) => (
+          <Group key={metric.label} justify="space-between">
+            <Text size="sm" c="dimmed">{metric.label}</Text>
+            <Text size="sm" fw={600} className="numeric-value">{metric.value}</Text>
+          </Group>
+        ))}
+      </Stack>
     )
   }
 

--- a/src/components/ytd-overview.tsx
+++ b/src/components/ytd-overview.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useMemo } from 'react'
+import { Calendar, CreditCard, DollarSign, PiggyBank, TrendingUp, Wallet, BarChart2 } from 'lucide-react'
+import { SimpleGrid, Title, Stack } from '@mantine/core'
+import { OverviewCard } from '@/components/overview-card'
+import { useCategoryStore, useExpenseStore, useIncomeStore } from '@/stores/instantdb'
+import { useInvestmentStore } from '@/stores/useInvestmentStore'
+
+export function YTDOverview() {
+  const currentDate = new Date()
+  const currentYear = currentDate.getFullYear()
+  const currentMonth = currentDate.getMonth() // 0-indexed
+
+  const { data: { expenseCategories = [] } = {} } = useCategoryStore()
+  const { data: { expenses = [] } = {} } = useExpenseStore()
+  const { data: { incomes = [] } = {} } = useIncomeStore()
+  const { investments, investmentContributions, getLatestValue } = useInvestmentStore()
+
+  const ytdData = useMemo(() => {
+    // YTD Income: All income from Jan 1 to current month of current year
+    const ytdIncome = incomes
+      .filter((income) => {
+        const incomeDate = new Date(income.date)
+        return (
+          incomeDate.getFullYear() === currentYear &&
+          incomeDate.getMonth() <= currentMonth
+        )
+      })
+      .reduce((total, income) => total + (income.amount || 0), 0)
+
+    // YTD Spent: All expenses from Jan 1 to current month of current year
+    const ytdSpent = expenses
+      .filter((expense) => {
+        const expenseDate = new Date(expense.date)
+        return (
+          expenseDate.getFullYear() === currentYear &&
+          expenseDate.getMonth() <= currentMonth
+        )
+      })
+      .reduce((total, expense) => total + (expense.amount || 0), 0)
+
+    // YTD Budget: Sum of all non-archived category monthly budgets × (current month + 1)
+    const monthsElapsed = currentMonth + 1
+    const ytdBudget = expenseCategories
+      .filter((category) => !category.isArchived)
+      .reduce((total, category) => total + (category.maxBudget || 0), 0) * monthsElapsed
+
+    // All-time investment contributions
+    const totalInvested = investmentContributions.reduce(
+      (total, contribution) => total + (contribution.amount || 0),
+      0
+    )
+
+    // Latest investment values (sum of latest value for each active investment)
+    const totalInvestmentValue = investments
+      .filter((investment) => investment.isActive)
+      .reduce((total, investment) => {
+        const latestValue = getLatestValue(investment.id)
+        return total + (latestValue || 0)
+      }, 0)
+
+    // YTD Savings
+    const ytdSavings = ytdIncome - ytdSpent
+
+    // YTD Savings Rate
+    const ytdSavingsRate = ytdIncome > 0 ? (ytdSavings / ytdIncome) * 100 : 0
+
+    return {
+      ytdIncome,
+      ytdSpent,
+      ytdBudget,
+      totalInvested,
+      totalInvestmentValue,
+      ytdSavings,
+      ytdSavingsRate
+    }
+  }, [
+    incomes,
+    expenses,
+    expenseCategories,
+    investments,
+    investmentContributions,
+    getLatestValue,
+    currentYear,
+    currentMonth
+  ])
+
+  const formatCurrency = (amount: number): string => {
+    return `$${amount.toFixed(2)}`
+  }
+
+  return (
+    <Stack gap="sm">
+      <Title order={4} c="dimmed">
+        <Calendar size={16} style={{ display: 'inline', marginRight: 8, verticalAlign: 'middle' }} />
+        Year to Date ({currentYear})
+      </Title>
+      <SimpleGrid cols={{ base: 2, xs: 2, sm: 3, md: 4, lg: 7 }} spacing="md">
+        <OverviewCard
+          title="YTD Budget"
+          value={formatCurrency(ytdData.ytdBudget)}
+          icon={<Wallet size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
+        />
+        <OverviewCard
+          title="YTD Spent"
+          value={formatCurrency(ytdData.ytdSpent)}
+          icon={<CreditCard size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
+        />
+        <OverviewCard
+          title="YTD Income"
+          value={formatCurrency(ytdData.ytdIncome)}
+          icon={<DollarSign size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
+        />
+        <OverviewCard
+          title="Total Invested"
+          value={formatCurrency(ytdData.totalInvested)}
+          icon={<PiggyBank size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
+        />
+        <OverviewCard
+          title="Investment Value"
+          value={formatCurrency(ytdData.totalInvestmentValue)}
+          icon={<TrendingUp size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
+        />
+        <OverviewCard
+          title="YTD Savings"
+          value={formatCurrency(ytdData.ytdSavings)}
+          icon={<PiggyBank size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
+        />
+        <OverviewCard
+          title="Savings Rate"
+          value={`${ytdData.ytdSavingsRate.toFixed(1)}%`}
+          icon={<BarChart2 size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
+        />
+      </SimpleGrid>
+    </Stack>
+  )
+}

--- a/src/routes/home-page.tsx
+++ b/src/routes/home-page.tsx
@@ -10,7 +10,7 @@ import { InvestmentOverview } from '@/components/investment/investment-overview'
 import { YTDOverview } from '@/components/ytd-overview'
 import { PageHeader } from '@/components/page-header'
 import { useSharedQueryParams } from '@/hooks/use-shared-query-params'
-import { Stack, Accordion, Box } from '@mantine/core'
+import { Stack, Accordion, Box, Card } from '@mantine/core'
 
 export default function HomePage() {
   const { selectedYear, selectedMonth } = useSharedQueryParams()
@@ -51,16 +51,18 @@ export default function HomePage() {
         <YTDOverview />
       </Box>
 
-      {/* YTD Overview - Mobile: collapsible (collapsed by default) */}
+      {/* YTD Overview - Mobile: collapsible inside a card */}
       <Box hiddenFrom="sm">
-        <Accordion>
-          <Accordion.Item value="ytd">
-            <Accordion.Control>Year to Date Overview</Accordion.Control>
-            <Accordion.Panel>
-              <YTDOverview compact />
-            </Accordion.Panel>
-          </Accordion.Item>
-        </Accordion>
+        <Card shadow="sm" padding={0} radius="md" withBorder>
+          <Accordion>
+            <Accordion.Item value="ytd" style={{ border: 'none' }}>
+              <Accordion.Control>Year to Date Overview</Accordion.Control>
+              <Accordion.Panel>
+                <YTDOverview compact />
+              </Accordion.Panel>
+            </Accordion.Item>
+          </Accordion>
+        </Card>
       </Box>
 
       <HomeOverview

--- a/src/routes/home-page.tsx
+++ b/src/routes/home-page.tsx
@@ -7,6 +7,7 @@ import { ExpenseOverview } from '@/components/expense-overview'
 import { HomeOverview } from '@/components/home-overview'
 import { IncomeOverview } from '@/components/income-overview'
 import { InvestmentOverview } from '@/components/investment/investment-overview'
+import { YTDOverview } from '@/components/ytd-overview'
 import { PageHeader } from '@/components/page-header'
 import { useSharedQueryParams } from '@/hooks/use-shared-query-params'
 import { Stack, Accordion, Box } from '@mantine/core'
@@ -45,6 +46,23 @@ export default function HomePage() {
 
   return (
     <Stack gap="lg">
+      {/* YTD Overview - Desktop: always visible */}
+      <Box visibleFrom="sm">
+        <YTDOverview />
+      </Box>
+
+      {/* YTD Overview - Mobile: collapsible (collapsed by default) */}
+      <Box hiddenFrom="sm">
+        <Accordion>
+          <Accordion.Item value="ytd">
+            <Accordion.Control>Year to Date Overview</Accordion.Control>
+            <Accordion.Panel>
+              <YTDOverview />
+            </Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>
+      </Box>
+
       <HomeOverview
         totalMonthlyIncomes={totalMonthlyIncomes}
         totalMonthlyExpenses={totalMonthlyExpenses}
@@ -52,7 +70,7 @@ export default function HomePage() {
         totalInvestmentValue={totalInvestmentValue}
       />
 
-      {/* Desktop view - regular stack */}
+      {/* Mobile view - regular stack */}
       <Box hiddenFrom="sm">
         <Stack gap="lg">
           <ExpenseOverview
@@ -73,7 +91,7 @@ export default function HomePage() {
         </Stack>
       </Box>
 
-      {/* Mobile view - accordion */}
+      {/* Desktop view - accordion for detailed sections */}
       <Box visibleFrom="sm">
         <Accordion multiple defaultValue={['expenses', 'incomes', 'investments']}>
           <Accordion.Item value="expenses">

--- a/src/routes/home-page.tsx
+++ b/src/routes/home-page.tsx
@@ -57,7 +57,7 @@ export default function HomePage() {
           <Accordion.Item value="ytd">
             <Accordion.Control>Year to Date Overview</Accordion.Control>
             <Accordion.Panel>
-              <YTDOverview />
+              <YTDOverview compact />
             </Accordion.Panel>
           </Accordion.Item>
         </Accordion>


### PR DESCRIPTION
- Create YTDOverview component showing 7 key metrics:
  - YTD Budget (monthly budgets × months elapsed)
  - YTD Spent (expenses this year)
  - YTD Income (income this year)
  - Total Invested (all-time contributions)
  - Investment Value (latest values)
  - YTD Savings (income - spent)
  - Savings Rate percentage
- Display above monthly overview on home page
- Collapsible on mobile, always visible on desktop
- Uses current year/month regardless of date picker selection