### PR TITLE
Migrate expenses table to Handsontable for spreadsheet-like experience

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,6 +31,8 @@ textarea {
 .expense-spreadsheet {
   font-family: var(--font-system);
   font-size: 14px;
+  width: 100%;
+  min-width: 100%;
 }
 
 /* Table borders and cells */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,7 +43,7 @@ textarea {
 
 .expense-spreadsheet td {
   border-color: #dee2e6 !important;
-  padding: 0 !important;
+  padding: 0 2px !important;
 }
 
 .expense-spreadsheet th {
@@ -51,9 +51,10 @@ textarea {
   border-color: #dee2e6 !important;
   color: #495057;
   font-weight: 600;
-  padding: 0 !important;
+  padding: 0 2px !important;
   font-size: 12px;
   vertical-align: middle;
+  text-align: inherit;
 }
 
 /* Selected cell */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,7 +43,7 @@ textarea {
 
 .expense-spreadsheet td {
   border-color: #dee2e6 !important;
-  padding: 4px 6px !important;
+  padding: 0 !important;
 }
 
 .expense-spreadsheet th {
@@ -51,8 +51,9 @@ textarea {
   border-color: #dee2e6 !important;
   color: #495057;
   font-weight: 600;
-  padding: 6px !important;
+  padding: 0 !important;
   font-size: 12px;
+  vertical-align: middle;
 }
 
 /* Selected cell */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,3 +26,105 @@ input[type="number"],
 textarea {
   field-sizing: content;
 }
+
+/* Handsontable Custom Styling - Match Mantine Theme */
+.expense-spreadsheet {
+  font-family: var(--font-system);
+  font-size: 14px;
+}
+
+/* Table borders and cells */
+.expense-spreadsheet .ht_master .wtHolder {
+  background: white;
+}
+
+.expense-spreadsheet td {
+  border-color: #dee2e6 !important;
+  padding: 8px !important;
+}
+
+.expense-spreadsheet th {
+  background: #f8f9fa !important;
+  border-color: #dee2e6 !important;
+  color: #495057;
+  font-weight: 600;
+  padding: 10px 8px !important;
+}
+
+/* Selected cell */
+.expense-spreadsheet .ht__highlight {
+  background: #e7f5ff !important;
+}
+
+.expense-spreadsheet .area {
+  background: #d0ebff !important;
+}
+
+/* Current cell border */
+.expense-spreadsheet .current.area {
+  border: 2px solid #228be6 !important;
+}
+
+/* Numeric cells - use monospace */
+.expense-spreadsheet td.htRight {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Row headers (if enabled) */
+.expense-spreadsheet .ht__row_header {
+  background: #f8f9fa !important;
+  color: #868e96;
+}
+
+/* Dropdown arrow */
+.expense-spreadsheet .htAutocompleteArrow {
+  color: #868e96;
+}
+
+/* Input field when editing */
+.expense-spreadsheet .handsontableInput {
+  font-family: var(--font-system);
+  font-size: 14px;
+  padding: 4px 8px;
+  border: 2px solid #228be6 !important;
+  border-radius: 4px;
+}
+
+/* Date picker integration */
+.expense-spreadsheet input[type="text"] {
+  font-family: var(--font-system);
+}
+
+/* Dropdown menu styling */
+.handsontable .htDropdownMenu {
+  font-family: var(--font-system);
+  font-size: 14px;
+}
+
+/* Autocomplete dropdown */
+.handsontable.listbox {
+  font-family: var(--font-system);
+  border: 1px solid #dee2e6;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.handsontable.listbox .ht_master table {
+  border: none;
+}
+
+.handsontable.listbox td.current {
+  background: #e7f5ff !important;
+  color: #228be6;
+}
+
+/* Invalid cells */
+.expense-spreadsheet .htInvalid {
+  background: #fff5f5 !important;
+  border: 1px solid #fa5252 !important;
+}
+
+/* Read-only cells */
+.expense-spreadsheet .htDimmed {
+  color: #868e96;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -30,9 +30,10 @@ textarea {
 /* Handsontable Custom Styling - Match Mantine Theme */
 .expense-spreadsheet {
   font-family: var(--font-system);
-  font-size: 14px;
+  font-size: 13px;
   width: 100%;
   min-width: 100%;
+  line-height: 1.3;
 }
 
 /* Table borders and cells */
@@ -42,7 +43,7 @@ textarea {
 
 .expense-spreadsheet td {
   border-color: #dee2e6 !important;
-  padding: 8px !important;
+  padding: 4px 6px !important;
 }
 
 .expense-spreadsheet th {
@@ -50,7 +51,8 @@ textarea {
   border-color: #dee2e6 !important;
   color: #495057;
   font-weight: 600;
-  padding: 10px 8px !important;
+  padding: 6px !important;
+  font-size: 12px;
 }
 
 /* Selected cell */
@@ -87,8 +89,8 @@ textarea {
 /* Input field when editing */
 .expense-spreadsheet .handsontableInput {
   font-family: var(--font-system);
-  font-size: 14px;
-  padding: 4px 8px;
+  font-size: 13px;
+  padding: 2px 4px;
   border: 2px solid #228be6 !important;
   border-radius: 4px;
 }
@@ -101,12 +103,13 @@ textarea {
 /* Dropdown menu styling */
 .handsontable .htDropdownMenu {
   font-family: var(--font-system);
-  font-size: 14px;
+  font-size: 13px;
 }
 
 /* Autocomplete dropdown */
 .handsontable.listbox {
   font-family: var(--font-system);
+  font-size: 13px;
   border: 1px solid #dee2e6;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import '@mantine/dates/styles.css'
 import '@mantine/notifications/styles.css'
 import './globals.css'
 import { Suspense } from 'react'
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import { ColorSchemeScript, MantineProvider, mantineHtmlProps, createTheme } from '@mantine/core'
 import { Notifications } from '@mantine/notifications'
 
@@ -19,6 +19,13 @@ const theme = createTheme({
 export const metadata: Metadata = {
   title: 'Buddy App',
   description: 'Personal finance management app'
+}
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false
 }
 
 export default function RootLayout({

--- a/src/components/expense-ai-converter.tsx
+++ b/src/components/expense-ai-converter.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState } from 'react'
 import { Expense, useCategoryStore, useExpenseStore } from '@/stores/instantdb'
 import { Button, Stack, Textarea, Title } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
-import { ExpenseTable } from '@/components/expense-table'
+import { ExpenseSpreadsheet } from '@/components/expense-spreadsheet'
 
 interface ExpenseAiConverterProps {
   onExpensesGenerated: (expenses: Expense[]) => void
@@ -143,7 +143,7 @@ export const ExpenseAiConverter: React.FC<ExpenseAiConverterProps> = ({ onExpens
           <Title order={3} size="h5">
             AI Generated Expenses
           </Title>
-          <ExpenseTable
+          <ExpenseSpreadsheet
             expenses={aiGeneratedExpenses}
             expenseCategories={expenseCategories}
             onInputChange={handleExpenseChange}

--- a/src/components/expense-spreadsheet.tsx
+++ b/src/components/expense-spreadsheet.tsx
@@ -58,8 +58,7 @@ export const ExpenseSpreadsheet: React.FC<ExpenseSpreadsheetProps> = ({
 
   // Transform expenses to Handsontable format
   const tableData = useMemo(() => {
-    return expenses.map((expense, index) => ({
-      rowNumber: index + 1,
+    return expenses.map((expense) => ({
       date: expense.date,
       description: expense.description,
       amount: expense.amount,
@@ -94,8 +93,8 @@ export const ExpenseSpreadsheet: React.FC<ExpenseSpreadsheetProps> = ({
         border: none;
         background: transparent;
         cursor: pointer;
-        font-size: 16px;
-        padding: 8px;
+        font-size: 14px;
+        padding: 2px;
         transition: background-color 0.2s;
       `
 
@@ -168,25 +167,12 @@ export const ExpenseSpreadsheet: React.FC<ExpenseSpreadsheetProps> = ({
   const columns: Handsontable.ColumnSettings[] = useMemo(
     () => [
       {
-        data: 'rowNumber',
-        title: '#',
-        width: 50,
-        readOnly: true,
-        className: 'htCenter htMiddle',
-        renderer: (instance, td, row, col, prop, value, cellProperties) => {
-          td.textContent = String(value)
-          td.style.color = '#868e96'
-          td.style.fontWeight = '500'
-          return td
-        }
-      },
-      {
         data: 'date',
         title: 'Date',
         type: 'date',
         dateFormat: 'YYYY-MM-DD',
         correctFormat: true,
-        width: 120,
+        width: 72,
         className: 'htMiddle'
       },
       {
@@ -203,7 +189,7 @@ export const ExpenseSpreadsheet: React.FC<ExpenseSpreadsheetProps> = ({
         numericFormat: {
           pattern: '0,0.00'
         },
-        width: 100,
+        width: 80,
         className: 'htMiddle htRight'
       },
       {
@@ -220,8 +206,9 @@ export const ExpenseSpreadsheet: React.FC<ExpenseSpreadsheetProps> = ({
       {
         data: 'id',
         title: 'Action',
-        width: 60,
+        width: 36,
         readOnly: true,
+        className: 'htMiddle htCenter',
         renderer: deleteButtonRenderer
       }
     ],

--- a/src/components/expense-spreadsheet.tsx
+++ b/src/components/expense-spreadsheet.tsx
@@ -233,14 +233,15 @@ export const ExpenseSpreadsheet: React.FC<ExpenseSpreadsheetProps> = ({
       <Text size="sm" c="dimmed">
         {expenses.length} {expenses.length === 1 ? 'item' : 'items'}
       </Text>
-      <div style={{ height: '50vh', overflow: 'auto' }}>
+      <div style={{ width: '100%', overflowX: 'auto' }}>
         <HotTable
           data={tableData}
           columns={columns}
           colHeaders={true}
           rowHeaders={false}
           licenseKey="non-commercial-and-evaluation"
-          height="100%"
+          height={400}
+          width="100%"
           stretchH="all"
           autoWrapRow={true}
           autoWrapCol={true}

--- a/src/components/expense-spreadsheet.tsx
+++ b/src/components/expense-spreadsheet.tsx
@@ -1,0 +1,261 @@
+'use client'
+
+import React, { useCallback, useMemo } from 'react'
+import { HotTable } from '@handsontable/react'
+import { registerAllModules } from 'handsontable/registry'
+import { Stack, Text, Button } from '@mantine/core'
+import { TrashIcon } from 'lucide-react'
+import { Expense, ExpenseCategory } from '@/stores/instantdb'
+import Handsontable from 'handsontable'
+import 'handsontable/dist/handsontable.full.min.css'
+
+// Register Handsontable modules
+registerAllModules()
+
+interface ExpenseSpreadsheetProps {
+  expenses: Expense[]
+  expenseCategories: ExpenseCategory[]
+  onInputChange: (
+    index: number,
+    field: 'amount' | 'categoryId' | 'date' | 'description',
+    value: string | number | Date
+  ) => void
+  onDeleteRow: (id: string) => void
+}
+
+export const ExpenseSpreadsheet: React.FC<ExpenseSpreadsheetProps> = ({
+  expenses,
+  expenseCategories,
+  onInputChange,
+  onDeleteRow
+}) => {
+
+  // Create category lookup maps
+  const categoryIdToName = useMemo(() => {
+    const map = new Map<string, string>()
+    expenseCategories.forEach((cat) => {
+      if (!cat.isArchived) {
+        map.set(cat.id, cat.name)
+      }
+    })
+    return map
+  }, [expenseCategories])
+
+  const categoryNameToId = useMemo(() => {
+    const map = new Map<string, string>()
+    expenseCategories.forEach((cat) => {
+      if (!cat.isArchived) {
+        map.set(cat.name, cat.id)
+      }
+    })
+    return map
+  }, [expenseCategories])
+
+  // Get active category names for dropdown
+  const categoryNames = useMemo(() => {
+    return expenseCategories.filter((cat) => !cat.isArchived).map((cat) => cat.name)
+  }, [expenseCategories])
+
+  // Transform expenses to Handsontable format
+  const tableData = useMemo(() => {
+    return expenses.map((expense, index) => ({
+      rowNumber: index + 1,
+      date: expense.date,
+      description: expense.description,
+      amount: expense.amount,
+      category: categoryIdToName.get(expense.categoryId) || '',
+      id: expense.id
+    }))
+  }, [expenses, categoryIdToName])
+
+  // Custom renderer for delete button
+  const deleteButtonRenderer = useCallback(
+    (
+      instance: Handsontable,
+      td: HTMLTableCellElement,
+      row: number,
+      col: number,
+      prop: string | number,
+      value: any,
+      cellProperties: Handsontable.CellProperties
+    ) => {
+      // Clear existing content
+      td.innerHTML = ''
+      td.style.padding = '0'
+      td.style.textAlign = 'center'
+      td.style.verticalAlign = 'middle'
+
+      // Create delete button
+      const button = document.createElement('button')
+      button.innerHTML = '🗑️'
+      button.style.cssText = `
+        width: 100%;
+        height: 100%;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        font-size: 16px;
+        padding: 8px;
+        transition: background-color 0.2s;
+      `
+
+      button.addEventListener('mouseenter', () => {
+        button.style.backgroundColor = '#fee'
+      })
+
+      button.addEventListener('mouseleave', () => {
+        button.style.backgroundColor = 'transparent'
+      })
+
+      button.addEventListener('click', (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        const expenseId = expenses[row]?.id
+        if (expenseId) {
+          onDeleteRow(expenseId)
+        }
+      })
+
+      td.appendChild(button)
+      return td
+    },
+    [expenses, onDeleteRow]
+  )
+
+  // Handle cell changes
+  const handleAfterChange = useCallback(
+    (changes: Handsontable.CellChange[] | null, source: Handsontable.ChangeSource) => {
+      if (!changes || source === 'loadData') return
+
+      changes.forEach(([row, prop, oldValue, newValue]) => {
+        if (oldValue === newValue) return
+
+        const expense = expenses[row]
+        if (!expense) return
+
+        switch (prop) {
+          case 'date':
+            if (newValue) {
+              // Convert date to ISO string
+              const dateObj = typeof newValue === 'string' ? new Date(newValue) : newValue
+              onInputChange(row, 'date', dateObj)
+            }
+            break
+
+          case 'description':
+            onInputChange(row, 'description', String(newValue || ''))
+            break
+
+          case 'amount':
+            const amount = Number(newValue)
+            if (!isNaN(amount)) {
+              onInputChange(row, 'amount', amount)
+            }
+            break
+
+          case 'category':
+            // Convert category name back to ID
+            const categoryId = categoryNameToId.get(String(newValue)) || ''
+            onInputChange(row, 'categoryId', categoryId)
+            break
+        }
+      })
+    },
+    [expenses, onInputChange, categoryNameToId]
+  )
+
+  // Column definitions
+  const columns: Handsontable.ColumnSettings[] = useMemo(
+    () => [
+      {
+        data: 'rowNumber',
+        title: '#',
+        width: 50,
+        readOnly: true,
+        className: 'htCenter htMiddle',
+        renderer: (instance, td, row, col, prop, value, cellProperties) => {
+          td.textContent = String(value)
+          td.style.color = '#868e96'
+          td.style.fontWeight = '500'
+          return td
+        }
+      },
+      {
+        data: 'date',
+        title: 'Date',
+        type: 'date',
+        dateFormat: 'YYYY-MM-DD',
+        correctFormat: true,
+        width: 120,
+        className: 'htMiddle'
+      },
+      {
+        data: 'description',
+        title: 'Description',
+        type: 'text',
+        className: 'htMiddle',
+        renderer: 'text'
+      },
+      {
+        data: 'amount',
+        title: 'Amount',
+        type: 'numeric',
+        numericFormat: {
+          pattern: '0,0.00'
+        },
+        width: 100,
+        className: 'htMiddle htRight'
+      },
+      {
+        data: 'category',
+        title: 'Category',
+        type: 'dropdown',
+        source: categoryNames,
+        width: 150,
+        className: 'htMiddle',
+        filter: true,
+        filteringCaseSensitive: false,
+        allowInvalid: true
+      },
+      {
+        data: 'id',
+        title: 'Action',
+        width: 60,
+        readOnly: true,
+        renderer: deleteButtonRenderer
+      }
+    ],
+    [categoryNames, deleteButtonRenderer]
+  )
+
+  return (
+    <Stack gap="sm">
+      <Text size="sm" c="dimmed">
+        {expenses.length} {expenses.length === 1 ? 'item' : 'items'}
+      </Text>
+      <div style={{ height: '50vh', overflow: 'auto' }}>
+        <HotTable
+          data={tableData}
+          columns={columns}
+          colHeaders={true}
+          rowHeaders={false}
+          licenseKey="non-commercial-and-evaluation"
+          height="100%"
+          stretchH="all"
+          autoWrapRow={true}
+          autoWrapCol={true}
+          enterMoves={{ row: 1, col: 0 }} // Enter moves down
+          tabMoves={{ row: 0, col: 1 }} // Tab moves right
+          copyPaste={true} // Enable copy/paste
+          search={true} // Enable search
+          manualColumnResize={true}
+          className="expense-spreadsheet"
+          afterChange={handleAfterChange}
+          // Styling
+          customBorders={false}
+          outsideClickDeselects={false}
+        />
+      </div>
+    </Stack>
+  )
+}

--- a/src/routes/expenses-page.tsx
+++ b/src/routes/expenses-page.tsx
@@ -102,7 +102,7 @@ export default function ExpensesPage() {
   }
 
   return (
-    <SimpleGrid cols={2} spacing="md">
+    <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
       {/* Left Panel - Entry Methods */}
       <Card withBorder p="lg">
         <Tabs defaultValue="ai-import">

--- a/src/routes/expenses-page.tsx
+++ b/src/routes/expenses-page.tsx
@@ -5,7 +5,7 @@ import { ExpenseList } from '@/components/expense-list'
 import { Card, Stack, Tabs, Group, NumberInput, Button, SimpleGrid } from '@mantine/core'
 import { useSharedQueryParams } from '@/hooks/use-shared-query-params'
 import { ExpenseAiConverter } from '@/components/expense-ai-converter'
-import { ExpenseTable } from '@/components/expense-table'
+import { ExpenseSpreadsheet } from '@/components/expense-spreadsheet'
 import { Expense, useCategoryStore, useExpenseStore } from '@/stores/instantdb'
 import { notifications } from '@mantine/notifications'
 import { SparklesIcon, TableIcon } from 'lucide-react'
@@ -121,7 +121,7 @@ export default function ExpensesPage() {
 
           <Tabs.Panel value="manual-entry" pt="md">
             <Stack gap="md">
-              <ExpenseTable
+              <ExpenseSpreadsheet
                 expenses={expenses}
                 expenseCategories={expenseCategories}
                 onInputChange={handleInputChange}


### PR DESCRIPTION
- Created new ExpenseSpreadsheet component using Handsontable
- Configured columns: Date, Description, Amount, Category (searchable dropdown)
- Enabled keyboard navigation (Tab, Enter, Arrow keys)
- Enabled copy/paste functionality (Ctrl+C/V)
- Replaced ExpenseTable with ExpenseSpreadsheet in expenses-page and expense-ai-converter
- Added custom CSS styling to match Mantine theme
- Build verified successfully

This improves the user experience for quick data entry and editing,
especially for the AI import workflow where users make minor adjustments
to categories and descriptions.