### PR TITLE
Redesign home dashboard with consistent styling

### DIFF
--- a/src/components/account-list.tsx
+++ b/src/components/account-list.tsx
@@ -2,10 +2,17 @@
 
 import React, { useState } from 'react'
 import { AccountBalance, useAccountBalances } from '@/stores/instantdb'
-import { Edit2, MoreVertical, Trash2 } from 'lucide-react'
+import { Edit2, Trash2 } from 'lucide-react'
 import { AccountForm } from '@/components/account-form'
-import { Button, Modal, Menu, Divider } from '@mantine/core'
+import { Button, Modal, Group, Text, Stack } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
+})
 
 interface AccountListProps {
   selectedYear: number
@@ -42,48 +49,30 @@ export const AccountList: React.FC<AccountListProps> = ({ selectedYear, selected
 
   return (
     <>
-      <div style={{ padding: '1.5rem' }}>
-        {accountBalances.length === 0 ? (
-          <p style={{ textAlign: 'center', color: 'var(--mantine-color-dimmed)', padding: '1rem 0' }}>
-            No account balances for this month.
-          </p>
-        ) : (
-          <ul style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-            {accountBalances.map((balance) => (
-              <li key={balance.id}>
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                  <div>
-                    <h3 style={{ fontWeight: 600 }}>{balance.title}</h3>
-                    <p style={{ fontSize: '0.875rem', color: 'var(--mantine-color-dimmed)' }}>ID: {balance.id}</p>
-                  </div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                    <div style={{ textAlign: 'right', fontWeight: 600 }}>${balance.amount.toFixed(2)}</div>
-                    <Menu shadow="md" width={200}>
-                      <Menu.Target>
-                        <Button variant="subtle" size="compact-sm" p={0}>
-                          <MoreVertical size={16} />
-                          <span style={{ position: 'absolute', width: '1px', height: '1px', overflow: 'hidden' }}>
-                            Actions
-                          </span>
-                        </Button>
-                      </Menu.Target>
-                      <Menu.Dropdown>
-                        <Menu.Item leftSection={<Edit2 size={16} />} onClick={() => handleEdit(balance)}>
-                          Edit
-                        </Menu.Item>
-                        <Menu.Item leftSection={<Trash2 size={16} />} color="red" onClick={() => handleDelete(balance)}>
-                          Delete
-                        </Menu.Item>
-                      </Menu.Dropdown>
-                    </Menu>
-                  </div>
-                </div>
-                <Divider my="sm" />
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+      {accountBalances.length === 0 ? (
+        <Text ta="center" c="dimmed" py="md">
+          No account balances for this month.
+        </Text>
+      ) : (
+        <Stack gap="xs">
+          {accountBalances.map((balance) => (
+            <Group key={balance.id} justify="space-between" wrap="nowrap">
+              <Text size="sm" fw={500}>{balance.title}</Text>
+              <Group gap="xs" wrap="nowrap">
+                <Text size="sm" fw={600} className="numeric-value">
+                  {currencyFormatter.format(balance.amount)}
+                </Text>
+                <Button size="compact-xs" variant="subtle" onClick={() => handleEdit(balance)}>
+                  <Edit2 size={12} />
+                </Button>
+                <Button size="compact-xs" variant="subtle" color="red" onClick={() => handleDelete(balance)}>
+                  <Trash2 size={12} />
+                </Button>
+              </Group>
+            </Group>
+          ))}
+        </Stack>
+      )}
 
       <Modal
         opened={editingAccount !== null}
@@ -107,15 +96,15 @@ export const AccountList: React.FC<AccountListProps> = ({ selectedYear, selected
         title="Are you sure?"
         centered
       >
-        <p>This action cannot be undone. This will permanently delete the account balance.</p>
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', marginTop: '1rem' }}>
+        <Text size="sm">This action cannot be undone. This will permanently delete the account balance.</Text>
+        <Group justify="flex-end" gap="sm" mt="md">
           <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)}>
             Cancel
           </Button>
           <Button color="red" onClick={confirmDelete}>
             Delete
           </Button>
-        </div>
+        </Group>
       </Modal>
     </>
   )

--- a/src/components/category-spreadsheet.tsx
+++ b/src/components/category-spreadsheet.tsx
@@ -1,0 +1,494 @@
+'use client'
+
+import React, { useCallback, useMemo, useState, useRef, useEffect } from 'react'
+import { HotTable, HotTableClass } from '@handsontable/react'
+import { registerAllModules } from 'handsontable/registry'
+import { Stack, Text, Button, Card, Group, Modal } from '@mantine/core'
+import { Plus, Save } from 'lucide-react'
+import { ExpenseCategory, IncomeCategory } from '@/stores/instantdb'
+import { notifications } from '@mantine/notifications'
+import Handsontable from 'handsontable'
+import 'handsontable/dist/handsontable.full.min.css'
+
+// Register Handsontable modules
+registerAllModules()
+
+type EditableExpenseCategory = Partial<ExpenseCategory> & {
+  id?: string
+  isNew?: boolean
+}
+
+type EditableIncomeCategory = Partial<IncomeCategory> & {
+  id?: string
+  isNew?: boolean
+}
+
+interface CategorySpreadsheetProps {
+  type: 'expense' | 'income'
+  categories: ExpenseCategory[] | IncomeCategory[]
+  onAdd: (category: Partial<ExpenseCategory | IncomeCategory>) => Promise<void>
+  onUpdate: (id: string, category: Partial<ExpenseCategory | IncomeCategory>) => Promise<void>
+  onDelete: (id: string) => Promise<void>
+}
+
+export const CategorySpreadsheet: React.FC<CategorySpreadsheetProps> = ({
+  type,
+  categories,
+  onAdd,
+  onUpdate,
+  onDelete
+}) => {
+  const hotRef = useRef<HotTableClass>(null)
+  const [hasChanges, setHasChanges] = useState(false)
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const [deletingCategoryId, setDeletingCategoryId] = useState<string | undefined>()
+  const [editableCategories, setEditableCategories] = useState<(EditableExpenseCategory | EditableIncomeCategory)[]>([])
+
+  // Initialize editable categories from props
+  useEffect(() => {
+    setEditableCategories(
+      categories.map((category) => ({
+        ...category,
+        isNew: false
+      }))
+    )
+    setHasChanges(false)
+  }, [categories])
+
+  // Transform categories to Handsontable format
+  const tableData = useMemo(() => {
+    if (type === 'expense') {
+      return (editableCategories as EditableExpenseCategory[]).map((category, index) => ({
+        name: category.name || '',
+        maxBudget: category.maxBudget ?? 0,
+        maxAnnualBudget: category.maxAnnualBudget ?? 0,
+        isArchived: category.isArchived || false,
+        id: category.id || `new-${index}`,
+        isNew: category.isNew || false,
+        rowIndex: index
+      }))
+    } else {
+      return (editableCategories as EditableIncomeCategory[]).map((category, index) => ({
+        title: category.title || '',
+        targetAmount: category.targetAmount ?? 0,
+        isArchived: category.isArchived || false,
+        id: category.id || `new-${index}`,
+        isNew: category.isNew || false,
+        rowIndex: index
+      }))
+    }
+  }, [editableCategories, type])
+
+  // Handle delete button click
+  const handleDelete = useCallback((categoryId: string) => {
+    if (categoryId.startsWith('new-')) {
+      // Remove new unsaved row
+      const index = parseInt(categoryId.replace('new-', ''))
+      setEditableCategories(prev => prev.filter((_, i) => i !== index))
+      setHasChanges(true)
+    } else {
+      setDeletingCategoryId(categoryId)
+      setIsDeleteDialogOpen(true)
+    }
+  }, [])
+
+  const confirmDelete = async () => {
+    if (deletingCategoryId) {
+      try {
+        await onDelete(deletingCategoryId)
+        setEditableCategories(prev => prev.filter((cat) => cat.id !== deletingCategoryId))
+        notifications.show({
+          title: 'Success',
+          message: 'Category deleted successfully',
+          color: 'green'
+        })
+      } catch (error) {
+        console.error('Category delete error:', error)
+        notifications.show({
+          title: 'Error',
+          message: 'Failed to delete category',
+          color: 'red'
+        })
+      }
+    }
+    setIsDeleteDialogOpen(false)
+    setDeletingCategoryId(undefined)
+  }
+
+  // Custom renderer for delete button
+  const deleteButtonRenderer = useCallback(
+    (
+      instance: Handsontable,
+      td: HTMLTableCellElement,
+      row: number,
+      col: number,
+      prop: string | number,
+      value: any,
+      cellProperties: Handsontable.CellProperties
+    ) => {
+      td.innerHTML = ''
+      td.style.padding = '0'
+      td.style.textAlign = 'center'
+      td.style.verticalAlign = 'middle'
+
+      const button = document.createElement('button')
+      button.innerHTML = '🗑️'
+      button.style.cssText = `
+        width: 100%;
+        height: 100%;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        font-size: 14px;
+        padding: 2px;
+        transition: background-color 0.2s;
+      `
+
+      button.addEventListener('mouseenter', () => {
+        button.style.backgroundColor = '#fee'
+      })
+
+      button.addEventListener('mouseleave', () => {
+        button.style.backgroundColor = 'transparent'
+      })
+
+      button.addEventListener('click', (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        const categoryId = tableData[row]?.id
+        if (categoryId) {
+          handleDelete(categoryId)
+        }
+      })
+
+      td.appendChild(button)
+      return td
+    },
+    [tableData, handleDelete]
+  )
+
+  // Custom renderer for checkbox
+  const checkboxRenderer = useCallback(
+    (
+      instance: Handsontable,
+      td: HTMLTableCellElement,
+      row: number,
+      col: number,
+      prop: string | number,
+      value: any,
+      cellProperties: Handsontable.CellProperties
+    ) => {
+      td.innerHTML = ''
+      td.style.textAlign = 'center'
+      td.style.verticalAlign = 'middle'
+
+      const checkbox = document.createElement('input')
+      checkbox.type = 'checkbox'
+      checkbox.checked = !!value
+      checkbox.style.cssText = `
+        width: 16px;
+        height: 16px;
+        cursor: pointer;
+      `
+
+      checkbox.addEventListener('change', (e) => {
+        const target = e.target as HTMLInputElement
+        instance.setDataAtRowProp(row, String(prop), target.checked)
+      })
+
+      td.appendChild(checkbox)
+      return td
+    },
+    []
+  )
+
+  // Handle cell changes
+  const handleAfterChange = useCallback(
+    (changes: Handsontable.CellChange[] | null, source: Handsontable.ChangeSource) => {
+      if (!changes || source === 'loadData') return
+
+      const updatedCategories = [...editableCategories]
+      let changed = false
+
+      changes.forEach(([row, prop, oldValue, newValue]) => {
+        if (oldValue === newValue) return
+
+        const category = updatedCategories[row]
+        if (!category) return
+
+        changed = true
+
+        if (type === 'expense') {
+          const expCat = category as EditableExpenseCategory
+          switch (prop) {
+            case 'name':
+              expCat.name = String(newValue || '')
+              break
+            case 'maxBudget':
+              expCat.maxBudget = Number(newValue) || 0
+              break
+            case 'maxAnnualBudget':
+              expCat.maxAnnualBudget = Number(newValue) || 0
+              break
+            case 'isArchived':
+              expCat.isArchived = !!newValue
+              break
+          }
+        } else {
+          const incCat = category as EditableIncomeCategory
+          switch (prop) {
+            case 'title':
+              incCat.title = String(newValue || '')
+              break
+            case 'targetAmount':
+              incCat.targetAmount = Number(newValue) || 0
+              break
+            case 'isArchived':
+              incCat.isArchived = !!newValue
+              break
+          }
+        }
+      })
+
+      if (changed) {
+        setEditableCategories(updatedCategories)
+        setHasChanges(true)
+      }
+    },
+    [editableCategories, type]
+  )
+
+  // Add new row
+  const handleAddRow = useCallback(() => {
+    const newCategory = type === 'expense'
+      ? { name: '', maxBudget: 0, maxAnnualBudget: 0, isArchived: false, isNew: true } as EditableExpenseCategory
+      : { title: '', targetAmount: 0, isArchived: false, isNew: true } as EditableIncomeCategory
+
+    setEditableCategories(prev => [...prev, newCategory])
+    setHasChanges(true)
+  }, [type])
+
+  // Validate category
+  const validateCategory = (category: EditableExpenseCategory | EditableIncomeCategory): boolean => {
+    if (type === 'expense') {
+      const expenseCategory = category as EditableExpenseCategory
+      if (!expenseCategory.name || expenseCategory.name.trim() === '') {
+        notifications.show({
+          title: 'Validation Error',
+          message: 'Category name is required',
+          color: 'red'
+        })
+        return false
+      }
+    } else {
+      const incomeCategory = category as EditableIncomeCategory
+      if (!incomeCategory.title || incomeCategory.title.trim() === '') {
+        notifications.show({
+          title: 'Validation Error',
+          message: 'Category title is required',
+          color: 'red'
+        })
+        return false
+      }
+    }
+    return true
+  }
+
+  // Save all changes
+  const handleSaveChanges = async () => {
+    let hasError = false
+
+    for (const category of editableCategories) {
+      if (!validateCategory(category)) {
+        hasError = true
+        break
+      }
+
+      try {
+        if (category.isNew) {
+          const { id, isNew, ...newCategory } = category
+          await onAdd(newCategory)
+        } else if (category.id) {
+          const { id, isNew, ...updateData } = category
+          await onUpdate(category.id, updateData)
+        }
+      } catch (error) {
+        console.error('Category save error:', error)
+        notifications.show({
+          title: 'Error',
+          message: `Failed to save category: ${error}`,
+          color: 'red'
+        })
+        hasError = true
+        break
+      }
+    }
+
+    if (!hasError) {
+      notifications.show({
+        title: 'Success',
+        message: 'All changes saved successfully',
+        color: 'green'
+      })
+      setHasChanges(false)
+    }
+  }
+
+  // Column definitions for expense categories
+  const expenseColumns: Handsontable.ColumnSettings[] = useMemo(
+    () => [
+      {
+        data: 'name',
+        title: 'Name',
+        type: 'text',
+        className: 'htMiddle htLeft'
+      },
+      {
+        data: 'maxBudget',
+        title: 'Monthly Budget',
+        type: 'numeric',
+        numericFormat: {
+          pattern: '0,0.00'
+        },
+        width: 120,
+        className: 'htMiddle htRight'
+      },
+      {
+        data: 'maxAnnualBudget',
+        title: 'Annual Budget',
+        type: 'numeric',
+        numericFormat: {
+          pattern: '0,0.00'
+        },
+        width: 120,
+        className: 'htMiddle htRight'
+      },
+      {
+        data: 'isArchived',
+        title: 'Archived',
+        width: 80,
+        className: 'htMiddle htCenter',
+        renderer: checkboxRenderer
+      },
+      {
+        data: 'id',
+        title: 'Action',
+        width: 60,
+        readOnly: true,
+        className: 'htMiddle htCenter',
+        renderer: deleteButtonRenderer
+      }
+    ],
+    [checkboxRenderer, deleteButtonRenderer]
+  )
+
+  // Column definitions for income categories
+  const incomeColumns: Handsontable.ColumnSettings[] = useMemo(
+    () => [
+      {
+        data: 'title',
+        title: 'Title',
+        type: 'text',
+        className: 'htMiddle htLeft'
+      },
+      {
+        data: 'targetAmount',
+        title: 'Target Amount',
+        type: 'numeric',
+        numericFormat: {
+          pattern: '0,0.00'
+        },
+        width: 120,
+        className: 'htMiddle htRight'
+      },
+      {
+        data: 'isArchived',
+        title: 'Archived',
+        width: 80,
+        className: 'htMiddle htCenter',
+        renderer: checkboxRenderer
+      },
+      {
+        data: 'id',
+        title: 'Action',
+        width: 60,
+        readOnly: true,
+        className: 'htMiddle htCenter',
+        renderer: deleteButtonRenderer
+      }
+    ],
+    [checkboxRenderer, deleteButtonRenderer]
+  )
+
+  const columns = type === 'expense' ? expenseColumns : incomeColumns
+
+  return (
+    <>
+      <Card shadow="sm" padding="lg" radius="md" withBorder>
+        <Card.Section withBorder inheritPadding py="md">
+          <Group justify="space-between">
+            <Text fw={700} size="lg">
+              {type === 'expense' ? 'Expense Categories' : 'Income Categories'}
+            </Text>
+            <Group gap="sm">
+              <Button variant="outline" onClick={handleAddRow} leftSection={<Plus size={16} />}>
+                Add Row
+              </Button>
+              <Button onClick={handleSaveChanges} disabled={!hasChanges} leftSection={<Save size={16} />}>
+                Save Changes
+              </Button>
+            </Group>
+          </Group>
+        </Card.Section>
+
+        <Card.Section inheritPadding py="md">
+          <Stack gap="sm">
+            <Text size="sm" c="dimmed">
+              {editableCategories.length} {editableCategories.length === 1 ? 'category' : 'categories'}
+            </Text>
+            <div style={{ width: '100%', overflowX: 'auto' }}>
+              <HotTable
+                ref={hotRef}
+                data={tableData}
+                columns={columns}
+                colHeaders={true}
+                rowHeaders={false}
+                licenseKey="non-commercial-and-evaluation"
+                height="auto"
+                width="100%"
+                stretchH="all"
+                autoWrapRow={true}
+                autoWrapCol={true}
+                enterMoves={{ row: 1, col: 0 }}
+                tabMoves={{ row: 0, col: 1 }}
+                copyPaste={true}
+                manualColumnResize={true}
+                className="category-spreadsheet"
+                afterChange={handleAfterChange}
+                customBorders={false}
+                outsideClickDeselects={false}
+              />
+            </div>
+          </Stack>
+        </Card.Section>
+      </Card>
+
+      <Modal
+        opened={isDeleteDialogOpen}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        title="Are you absolutely sure?"
+        centered
+      >
+        <Text size="sm">This action cannot be undone. This will permanently delete the category.</Text>
+        <Group justify="flex-end" gap="sm" mt="md">
+          <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)}>
+            Cancel
+          </Button>
+          <Button color="red" onClick={confirmDelete}>
+            Delete
+          </Button>
+        </Group>
+      </Modal>
+    </>
+  )
+}

--- a/src/components/expense-overview.tsx
+++ b/src/components/expense-overview.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useMemo } from 'react'
 import { Expense, ExpenseCategory } from '@/stores/instantdb'
 import { NavLink } from 'react-router'
-import { Anchor, Badge, Card, Table, Title, Text, Tooltip, ScrollArea } from '@mantine/core'
+import { Anchor, Badge, Table, ScrollArea } from '@mantine/core'
 
 // Utility functions moved outside component to prevent recreation
 const formatCurrency = (amount: number | undefined): string => {
@@ -101,16 +101,8 @@ export function ExpenseOverview({ expenses, expenseCategories, selectedYear, sel
   )
 
   return (
-    <Card withBorder padding="0">
-      <Card.Section withBorder inheritPadding py="sm">
-        <Title order={3} size="h4" mb={4}>Expense Categories</Title>
-        <Text size="sm" c="dimmed">
-          Monthly budget tracking and year-to-date overview
-        </Text>
-      </Card.Section>
-      <Card.Section>
-        <ScrollArea>
-          <Table striped highlightOnHover miw={800}>
+    <ScrollArea>
+      <Table striped highlightOnHover miw={800}>
             <Table.Thead>
               <Table.Tr>
                 <Table.Th>Category</Table.Th>
@@ -186,8 +178,6 @@ export function ExpenseOverview({ expenses, expenseCategories, selectedYear, sel
               )}
             </Table.Tbody>
           </Table>
-        </ScrollArea>
-      </Card.Section>
-    </Card>
+    </ScrollArea>
   )
 }

--- a/src/components/home-overview.tsx
+++ b/src/components/home-overview.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { BarChart2, CreditCard, Package2, PiggyBank, TrendingUp } from 'lucide-react'
-import { SimpleGrid } from '@mantine/core'
-import { OverviewCard } from '@/components/overview-card'
+import { Calendar } from 'lucide-react'
+import { Card, Title, Stack, Group, Text } from '@mantine/core'
+import { useSharedQueryParams } from '@/hooks/use-shared-query-params'
 
 interface HomeOverviewProps {
   totalMonthlyIncomes: number
@@ -11,38 +11,50 @@ interface HomeOverviewProps {
   totalInvestmentValue: number
 }
 
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
+})
+
 export function HomeOverview({ totalMonthlyIncomes, totalMonthlyExpenses, netIncome, totalInvestmentValue }: HomeOverviewProps) {
+  const { selectedYear, selectedMonth } = useSharedQueryParams()
+
   const formatCurrency = (amount: number | undefined): string => {
-    return amount !== undefined ? `$${amount.toFixed(2)}` : 'N/A'
+    return amount !== undefined ? currencyFormatter.format(amount) : 'N/A'
   }
 
+  const savingRate = totalMonthlyIncomes > 0
+    ? `${((netIncome / totalMonthlyIncomes) * 100).toFixed(1)}%`
+    : 'N/A'
+
+  const monthName = new Date(selectedYear, selectedMonth).toLocaleString('en-US', { month: 'long' })
+
+  const metrics = [
+    { label: 'Total Income', value: formatCurrency(totalMonthlyIncomes) },
+    { label: 'Total Expenses', value: formatCurrency(totalMonthlyExpenses) },
+    { label: 'Net Income', value: formatCurrency(netIncome) },
+    { label: 'Investments', value: formatCurrency(totalInvestmentValue) },
+    { label: 'Saving Rate', value: savingRate }
+  ]
+
   return (
-    <SimpleGrid cols={{ base: 1, xs: 2, sm: 3, md: 5 }} spacing="md">
-      <OverviewCard
-        title={'Total Income'}
-        value={formatCurrency(totalMonthlyIncomes)}
-        icon={<PiggyBank size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
-      />
-      <OverviewCard
-        title={'Total Expenses'}
-        value={formatCurrency(totalMonthlyExpenses)}
-        icon={<CreditCard size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
-      />
-      <OverviewCard
-        title={'Net Income'}
-        value={formatCurrency(netIncome)}
-        icon={<Package2 size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
-      />
-      <OverviewCard
-        title={'Investments'}
-        value={formatCurrency(totalInvestmentValue)}
-        icon={<TrendingUp size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
-      />
-      <OverviewCard
-        title={'Saving Rate'}
-        value={totalMonthlyIncomes > 0 ? `${((netIncome / totalMonthlyIncomes) * 100).toFixed(2)}%` : 'N/A'}
-        icon={<BarChart2 size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
-      />
-    </SimpleGrid>
+    <Card shadow="sm" padding="md" radius="md" withBorder>
+      <Stack gap="md">
+        <Group gap="xs">
+          <Calendar size={18} style={{ color: 'var(--mantine-color-dimmed)' }} />
+          <Title order={4} c="dimmed">{monthName} {selectedYear}</Title>
+        </Group>
+        <Stack gap="xs">
+          {metrics.map((metric) => (
+            <Group key={metric.label} justify="space-between">
+              <Text size="sm" c="dimmed">{metric.label}</Text>
+              <Text size="sm" fw={600} className="numeric-value">{metric.value}</Text>
+            </Group>
+          ))}
+        </Stack>
+      </Stack>
+    </Card>
   )
 }

--- a/src/components/income-list.tsx
+++ b/src/components/income-list.tsx
@@ -5,7 +5,7 @@ import { Income, useCategoryStore, useIncomeStore } from '@/stores/instantdb'
 import { format } from 'date-fns'
 import { Edit, Search, Trash } from 'lucide-react'
 import { useQueryState } from 'nuqs'
-import { Button, Card, TextInput, Select } from '@mantine/core'
+import { Button, Group, Stack, Text, TextInput, Select, Table, ScrollArea } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
 import { DeleteConfirmation } from './delete-confirmation'
 import { TransactionForm } from './transaction-form'
@@ -87,18 +87,16 @@ export const IncomeList: React.FC<IncomeListProps> = ({ selectedMonth, selectedY
   }, [incomeCategories])
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+    <Stack gap="md">
+      <Stack gap="sm">
         <TextInput
           placeholder="Search incomes..."
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
           leftSection={<Search size={16} />}
         />
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-          <span style={{ fontSize: '0.875rem', color: 'var(--mantine-color-dimmed)', whiteSpace: 'nowrap' }}>
-            Filter by category:
-          </span>
+        <Group gap="sm" align="center">
+          <Text size="sm" c="dimmed" style={{ whiteSpace: 'nowrap' }}>Filter:</Text>
           <Select
             value={selectedCategoryId || 'all'}
             onChange={(value) => setSelectedCategoryId(value === 'all' ? null : value)}
@@ -110,58 +108,52 @@ export const IncomeList: React.FC<IncomeListProps> = ({ selectedMonth, selectedY
                 label: category.name
               }))
             ]}
-            style={{ flex: 1 }}
+            flex={1}
           />
-        </div>
-      </div>
+        </Group>
+      </Stack>
 
       {filteredAndSortedIncomes.length === 0 ? (
-        <p style={{ textAlign: 'center', color: 'var(--mantine-color-dimmed)', padding: '1rem 0' }}>
-          No incomes found for this period.
-        </p>
+        <Text ta="center" c="dimmed" py="xl">No incomes found for this period.</Text>
       ) : (
-        <Card padding={0}>
-          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-            {filteredAndSortedIncomes.map((income) => (
-              <li key={income.id} style={{ padding: '1rem', borderBottom: '1px solid var(--mantine-color-gray-3)' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <div>
-                    <h3 style={{ fontWeight: 600, margin: 0 }}>{income.description}</h3>
-                    <p style={{ fontSize: '0.875rem', color: 'var(--mantine-color-dimmed)', margin: 0 }}>
-                      {income.category}
-                    </p>
-                  </div>
-                  <div style={{ textAlign: 'right' }}>
-                    <p style={{ fontWeight: 600, margin: 0 }}>${income.amount.toFixed(2)}</p>
-                    <p style={{ fontSize: '0.875rem', color: 'var(--mantine-color-dimmed)', margin: 0 }}>
-                      {format(new Date(income.date), 'dd MMM yyyy')}
-                    </p>
-                  </div>
-                </div>
-                <div style={{ marginTop: '0.5rem', display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
-                  <Button
-                    variant="subtle"
-                    size="sm"
-                    onClick={() => setEditingIncome(income)}
-                    color="blue"
-                    leftSection={<Edit size={16} />}
-                  >
-                    Edit
-                  </Button>
-                  <Button
-                    variant="subtle"
-                    size="sm"
-                    onClick={() => handleDeleteClick(income)}
-                    color="red"
-                    leftSection={<Trash size={16} />}
-                  >
-                    Delete
-                  </Button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </Card>
+        <Stack gap="sm">
+          <Text size="sm" c="dimmed">
+            {filteredAndSortedIncomes.length} {filteredAndSortedIncomes.length === 1 ? 'item' : 'items'}
+          </Text>
+          <ScrollArea>
+            <Table highlightOnHover striped withTableBorder miw={500} fz="xs" verticalSpacing="xs">
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th w={90}>Date</Table.Th>
+                  <Table.Th>Description</Table.Th>
+                  <Table.Th>Category</Table.Th>
+                  <Table.Th ta="right" w={80}>Amount</Table.Th>
+                  <Table.Th w={70}>Actions</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {filteredAndSortedIncomes.map((income) => (
+                  <Table.Tr key={income.id}>
+                    <Table.Td>{format(new Date(income.date), 'dd MMM yyyy')}</Table.Td>
+                    <Table.Td>{income.description}</Table.Td>
+                    <Table.Td c="dimmed">{income.category}</Table.Td>
+                    <Table.Td ta="right" className="numeric-value">${Number(income.amount).toFixed(2)}</Table.Td>
+                    <Table.Td>
+                      <Group gap="xs" wrap="nowrap">
+                        <Button size="compact-xs" variant="subtle" onClick={() => setEditingIncome(income)}>
+                          <Edit size={12} />
+                        </Button>
+                        <Button size="compact-xs" variant="subtle" color="red" onClick={() => handleDeleteClick(income)}>
+                          <Trash size={12} />
+                        </Button>
+                      </Group>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </ScrollArea>
+        </Stack>
       )}
 
       <DeleteConfirmation
@@ -189,6 +181,6 @@ export const IncomeList: React.FC<IncomeListProps> = ({ selectedMonth, selectedY
         categories={incomeCategories}
         initialData={editingIncome || undefined}
       />
-    </div>
+    </Stack>
   )
 }

--- a/src/components/income-overview.tsx
+++ b/src/components/income-overview.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from 'react'
 import { Income, IncomeCategory } from '@/stores/instantdb'
 import { NavLink } from 'react-router'
-import { Card, Table, Title, Text, Anchor, ScrollArea } from '@mantine/core'
+import { Table, Anchor, ScrollArea } from '@mantine/core'
 
 interface IncomeOverviewProps {
   incomes: Income[]
@@ -72,16 +72,8 @@ export function IncomeOverview({ incomes, incomeCategories, selectedYear, select
   }
 
   return (
-    <Card withBorder padding="0">
-      <Card.Section withBorder inheritPadding py="sm">
-        <Title order={3} size="h4" mb={4}>Income Categories</Title>
-        <Text size="sm" c="dimmed">
-          Monthly income tracking and year-to-date overview
-        </Text>
-      </Card.Section>
-      <Card.Section>
-        <ScrollArea>
-          <Table striped highlightOnHover miw={600}>
+    <ScrollArea>
+      <Table striped highlightOnHover miw={600}>
             <Table.Thead>
               <Table.Tr>
                 <Table.Th>Category</Table.Th>
@@ -117,8 +109,6 @@ export function IncomeOverview({ incomes, incomeCategories, selectedYear, select
             })}
             </Table.Tbody>
           </Table>
-        </ScrollArea>
-      </Card.Section>
-    </Card>
+    </ScrollArea>
   )
 }

--- a/src/components/investment/contribution-table.tsx
+++ b/src/components/investment/contribution-table.tsx
@@ -2,8 +2,8 @@
 
 import { useMemo, useState } from 'react'
 import { InvestmentContribution } from '@/types/investment'
-import { Edit, Trash2 } from 'lucide-react'
-import { Button, Card, Table, Group, Title, Text, Center } from '@mantine/core'
+import { Edit, Trash2, PiggyBank } from 'lucide-react'
+import { Button, Card, Table, Group, Title, Text, Center, Stack } from '@mantine/core'
 import ContributionForm from './forms/contribution-form'
 
 interface ContributionTableProps {
@@ -50,18 +50,20 @@ export default function ContributionTable({ investmentId, contributions, onDelet
   }
 
   return (
-    <Card shadow="sm" padding="0" radius="md" withBorder>
-      <Card.Section withBorder inheritPadding py="xs" bg="gray.0">
+    <Card shadow="sm" padding="md" radius="md" withBorder>
+      <Stack gap="md">
         <Group justify="space-between" align="center">
-          <Title order={3} size="lg">Contributions</Title>
+          <Group gap="xs">
+            <PiggyBank size={18} style={{ color: 'var(--mantine-color-dimmed)' }} />
+            <Title order={4} c="dimmed">Contributions</Title>
+          </Group>
           {!showForm && (
-            <Button size="sm" onClick={() => setShowForm(true)}>
-              Add Contribution
+            <Button size="xs" onClick={() => setShowForm(true)}>
+              Add
             </Button>
           )}
         </Group>
-      </Card.Section>
-      <Card.Section inheritPadding py="md">
+
         {showForm ? (
           <ContributionForm
             investmentId={investmentId}
@@ -70,28 +72,30 @@ export default function ContributionTable({ investmentId, contributions, onDelet
             onCancel={handleCancel}
           />
         ) : sortedContributions.length > 0 ? (
-          <Table>
+          <Table striped highlightOnHover fz="xs" verticalSpacing="xs">
             <Table.Thead>
               <Table.Tr>
                 <Table.Th>Date</Table.Th>
-                <Table.Th>Amount</Table.Th>
+                <Table.Th ta="right">Amount</Table.Th>
                 <Table.Th>Description</Table.Th>
-                <Table.Th ta="right">Actions</Table.Th>
+                <Table.Th ta="right" w={60}>Actions</Table.Th>
               </Table.Tr>
             </Table.Thead>
             <Table.Tbody>
               {sortedContributions.map((contribution) => (
                 <Table.Tr key={contribution.id}>
                   <Table.Td>{formatDate(contribution.date)}</Table.Td>
-                  <Table.Td className="numeric-value">{formatCurrency(contribution.amount)}</Table.Td>
-                  <Table.Td>{contribution.description || '-'}</Table.Td>
+                  <Table.Td ta="right" className="numeric-value">{formatCurrency(contribution.amount)}</Table.Td>
+                  <Table.Td c="dimmed">{contribution.description || '-'}</Table.Td>
                   <Table.Td ta="right">
-                    <Button variant="subtle" size="compact-sm" onClick={() => handleEdit(contribution)}>
-                      <Edit size={16} />
-                    </Button>
-                    <Button variant="subtle" size="compact-sm" color="red" onClick={() => onDelete(contribution.id)}>
-                      <Trash2 size={16} />
-                    </Button>
+                    <Group gap="xs" wrap="nowrap" justify="flex-end">
+                      <Button variant="subtle" size="compact-xs" onClick={() => handleEdit(contribution)}>
+                        <Edit size={12} />
+                      </Button>
+                      <Button variant="subtle" size="compact-xs" color="red" onClick={() => onDelete(contribution.id)}>
+                        <Trash2 size={12} />
+                      </Button>
+                    </Group>
                   </Table.Td>
                 </Table.Tr>
               ))}
@@ -99,10 +103,10 @@ export default function ContributionTable({ investmentId, contributions, onDelet
           </Table>
         ) : (
           <Center p="md">
-            <Text c="dimmed">No contributions yet</Text>
+            <Text c="dimmed" size="sm">No contributions yet</Text>
           </Center>
         )}
-      </Card.Section>
+      </Stack>
     </Card>
   )
 }

--- a/src/components/investment/investment-overview.tsx
+++ b/src/components/investment/investment-overview.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
-import { TrendingUp } from 'lucide-react'
-import { Card, Table, Stack, SimpleGrid, Title, Text, Group, ScrollArea } from '@mantine/core'
+import { Table, Stack, SimpleGrid, Text, ScrollArea } from '@mantine/core'
 import { useInvestmentStore } from '@/stores/useInvestmentStore'
 
 export function InvestmentOverview() {
@@ -66,66 +65,49 @@ export function InvestmentOverview() {
 
   return (
     <Stack gap="md">
-      <Card shadow="sm" padding="0" radius="md" withBorder>
-        <Card.Section withBorder inheritPadding py="xs" bg="gray.0">
-          <Group gap="xs">
-            <TrendingUp size={20} />
-            <Title order={3} size="h5">Investment Summary</Title>
-          </Group>
-        </Card.Section>
-        <Card.Section inheritPadding py="md">
-          <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
-            <Stack gap="xs">
-              <Text size="sm" fw={500} c="dimmed">Total Value</Text>
-              <Text size="xl" fw={700} className="numeric-value">{formatCurrency(totalInvestmentValue)}</Text>
-            </Stack>
-            <Stack gap="xs">
-              <Text size="sm" fw={500} c="dimmed">Total Invested</Text>
-              <Text size="xl" fw={700} className="numeric-value">{formatCurrency(totalContributions)}</Text>
-            </Stack>
-            <Stack gap="xs">
-              <Text size="sm" fw={500} c="dimmed">Total P&L</Text>
-              <Text size="xl" fw={700} c={totalProfitLoss >= 0 ? 'green.6' : 'red.6'} className="numeric-value">
-                {formatCurrency(totalProfitLoss)} ({profitLossPercentage.toFixed(2)}%)
-              </Text>
-            </Stack>
-          </SimpleGrid>
-        </Card.Section>
-      </Card>
+      <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
+        <Stack gap="xs">
+          <Text size="sm" fw={500} c="dimmed">Total Value</Text>
+          <Text size="xl" fw={700} className="numeric-value">{formatCurrency(totalInvestmentValue)}</Text>
+        </Stack>
+        <Stack gap="xs">
+          <Text size="sm" fw={500} c="dimmed">Total Invested</Text>
+          <Text size="xl" fw={700} className="numeric-value">{formatCurrency(totalContributions)}</Text>
+        </Stack>
+        <Stack gap="xs">
+          <Text size="sm" fw={500} c="dimmed">Total P&L</Text>
+          <Text size="xl" fw={700} c={totalProfitLoss >= 0 ? 'green.6' : 'red.6'} className="numeric-value">
+            {formatCurrency(totalProfitLoss)} ({profitLossPercentage.toFixed(2)}%)
+          </Text>
+        </Stack>
+      </SimpleGrid>
 
-      <Card shadow="sm" padding="0" radius="md" withBorder>
-        <Card.Section withBorder inheritPadding py="xs" bg="gray.0">
-          <Title order={3} size="h5">Active Investments</Title>
-        </Card.Section>
-        <Card.Section>
-          <ScrollArea>
-            <Table style={{ minWidth: 600 }}>
-              <Table.Thead>
-                <Table.Tr>
-                  <Table.Th>Name</Table.Th>
-                  <Table.Th ta="right">Current Value</Table.Th>
-                  <Table.Th ta="right">Total Invested</Table.Th>
-                  <Table.Th ta="right">P&L</Table.Th>
-                </Table.Tr>
-              </Table.Thead>
-              <Table.Tbody>
-                {investmentData.map((investment) => (
-                  <Table.Tr key={investment.id}>
-                    <Table.Td fw={500}>{investment.name}</Table.Td>
-                    <Table.Td ta="right" className="numeric-value">{formatCurrency(investment.currentValue)}</Table.Td>
-                    <Table.Td ta="right" className="numeric-value">{formatCurrency(investment.totalContributions)}</Table.Td>
-                    <Table.Td ta="right">
-                      <Text c={investment.profit >= 0 ? 'green.6' : 'red.6'} className="numeric-value">
-                        {formatCurrency(investment.profit)} ({investment.profitPercentage.toFixed(2)}%)
-                      </Text>
-                    </Table.Td>
-                  </Table.Tr>
-                ))}
-              </Table.Tbody>
-            </Table>
-          </ScrollArea>
-        </Card.Section>
-      </Card>
+      <ScrollArea>
+        <Table striped highlightOnHover style={{ minWidth: 600 }}>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Name</Table.Th>
+              <Table.Th ta="right">Current Value</Table.Th>
+              <Table.Th ta="right">Total Invested</Table.Th>
+              <Table.Th ta="right">P&L</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {investmentData.map((investment) => (
+              <Table.Tr key={investment.id}>
+                <Table.Td fw={500}>{investment.name}</Table.Td>
+                <Table.Td ta="right" className="numeric-value">{formatCurrency(investment.currentValue)}</Table.Td>
+                <Table.Td ta="right" className="numeric-value">{formatCurrency(investment.totalContributions)}</Table.Td>
+                <Table.Td ta="right">
+                  <Text c={investment.profit >= 0 ? 'green.6' : 'red.6'} className="numeric-value">
+                    {formatCurrency(investment.profit)} ({investment.profitPercentage.toFixed(2)}%)
+                  </Text>
+                </Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+      </ScrollArea>
     </Stack>
   )
 }

--- a/src/components/investment/performance-graph.tsx
+++ b/src/components/investment/performance-graph.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useMemo } from 'react'
-import { Card } from '@mantine/core'
+import { Card, Stack, Group, Title, Text } from '@mantine/core'
+import { TrendingUp } from 'lucide-react'
 import { InvestmentContribution, InvestmentValue } from '@/types/investment'
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts'
 
@@ -81,64 +82,69 @@ export default function PerformanceGraph({ contributions, values }: PerformanceG
   // If there's no data, show a message
   if (chartData.length === 0 || (contributions.length === 0 && values.length === 0)) {
     return (
-      <Card shadow="sm" padding="0" radius="md" withBorder>
-        <Card.Section withBorder inheritPadding py="xs" style={{ backgroundColor: 'var(--mantine-color-gray-0)' }}>
-          <h3 style={{ fontSize: '1.125rem', fontWeight: 600, margin: 0 }}>Performance</h3>
-        </Card.Section>
-        <Card.Section inheritPadding py="md" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '16rem' }}>
-          <p style={{ color: 'var(--mantine-color-dimmed)' }}>Add contributions and values to see performance data</p>
-        </Card.Section>
+      <Card shadow="sm" padding="md" radius="md" withBorder>
+        <Stack gap="md">
+          <Group gap="xs">
+            <TrendingUp size={18} style={{ color: 'var(--mantine-color-dimmed)' }} />
+            <Title order={4} c="dimmed">Performance</Title>
+          </Group>
+          <Stack align="center" justify="center" mih="10rem">
+            <Text c="dimmed" size="sm">Add contributions and values to see performance data</Text>
+          </Stack>
+        </Stack>
       </Card>
     )
   }
 
   return (
-    <Card shadow="sm" padding="0" radius="md" withBorder>
-      <Card.Section withBorder inheritPadding py="xs" style={{ backgroundColor: 'var(--mantine-color-gray-0)' }}>
-        <h3 style={{ fontSize: '1.125rem', fontWeight: 600, margin: 0 }}>Performance</h3>
-      </Card.Section>
-      <Card.Section inheritPadding py="md">
-        <div style={{ height: '20rem' }}>
+    <Card shadow="sm" padding="md" radius="md" withBorder>
+      <Stack gap="md">
+        <Group gap="xs">
+          <TrendingUp size={18} style={{ color: 'var(--mantine-color-dimmed)' }} />
+          <Title order={4} c="dimmed">Performance</Title>
+        </Group>
+        <div style={{ height: '10rem' }}>
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
               data={chartData}
               margin={{
                 top: 5,
-                right: 30,
-                left: 20,
+                right: 10,
+                left: 0,
                 bottom: 5,
               }}
             >
               <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="month" />
-              <YAxis />
+              <XAxis dataKey="month" tick={{ fontSize: 10 }} />
+              <YAxis tick={{ fontSize: 10 }} width={50} />
               <Tooltip
                 formatter={(value) => {
-                  // Ensure value is a number
                   const numValue = typeof value === 'string' ? parseFloat(value) :
                                   Array.isArray(value) ? parseFloat(value[0].toString()) :
                                   Number(value);
                   return [`$${numValue.toFixed(2)}`, undefined];
                 }}
               />
-              <Legend />
+              <Legend wrapperStyle={{ fontSize: '12px' }} />
               <Line
                 type="monotone"
                 dataKey="contributions"
                 name="Contributions"
                 stroke="#8884d8"
-                activeDot={{ r: 8 }}
+                activeDot={{ r: 6 }}
+                strokeWidth={2}
               />
               <Line
                 type="monotone"
                 dataKey="value"
                 name="Value"
                 stroke="#82ca9d"
+                strokeWidth={2}
               />
             </LineChart>
           </ResponsiveContainer>
         </div>
-      </Card.Section>
+      </Stack>
     </Card>
   )
 }

--- a/src/components/investment/value-table.tsx
+++ b/src/components/investment/value-table.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { Edit, Trash2 } from 'lucide-react'
-import { Button, Card, Table, Group, Title, Text, Center } from '@mantine/core'
+import { Edit, Trash2, BarChart3 } from 'lucide-react'
+import { Button, Card, Table, Group, Title, Text, Center, Stack } from '@mantine/core'
 import { InvestmentValue } from '@/types/investment'
 import ValueForm from './forms/value-form'
 
@@ -50,18 +50,20 @@ export default function ValueTable({ investmentId, values, onDelete }: ValueTabl
   }
 
   return (
-    <Card shadow="sm" padding="0" radius="md" withBorder>
-      <Card.Section withBorder inheritPadding py="xs" bg="gray.0">
+    <Card shadow="sm" padding="md" radius="md" withBorder>
+      <Stack gap="md">
         <Group justify="space-between" align="center">
-          <Title order={3} size="lg">Values</Title>
+          <Group gap="xs">
+            <BarChart3 size={18} style={{ color: 'var(--mantine-color-dimmed)' }} />
+            <Title order={4} c="dimmed">Values</Title>
+          </Group>
           {!showForm && (
-            <Button size="sm" onClick={() => setShowForm(true)}>
-              Add Value
+            <Button size="xs" onClick={() => setShowForm(true)}>
+              Add
             </Button>
           )}
         </Group>
-      </Card.Section>
-      <Card.Section inheritPadding py="md">
+
         {showForm ? (
           <ValueForm
             investmentId={investmentId}
@@ -70,28 +72,30 @@ export default function ValueTable({ investmentId, values, onDelete }: ValueTabl
             onCancel={handleCancel}
           />
         ) : sortedValues.length > 0 ? (
-          <Table>
+          <Table striped highlightOnHover fz="xs" verticalSpacing="xs">
             <Table.Thead>
               <Table.Tr>
                 <Table.Th>Date</Table.Th>
-                <Table.Th>Value</Table.Th>
+                <Table.Th ta="right">Value</Table.Th>
                 <Table.Th>Description</Table.Th>
-                <Table.Th ta="right">Actions</Table.Th>
+                <Table.Th ta="right" w={60}>Actions</Table.Th>
               </Table.Tr>
             </Table.Thead>
             <Table.Tbody>
               {sortedValues.map((value) => (
                 <Table.Tr key={value.id}>
                   <Table.Td>{formatDate(value.date)}</Table.Td>
-                  <Table.Td className="numeric-value">{formatCurrency(value.value)}</Table.Td>
-                  <Table.Td>{value.description || '-'}</Table.Td>
+                  <Table.Td ta="right" className="numeric-value">{formatCurrency(value.value)}</Table.Td>
+                  <Table.Td c="dimmed">{value.description || '-'}</Table.Td>
                   <Table.Td ta="right">
-                    <Button variant="subtle" size="compact-sm" onClick={() => handleEdit(value)}>
-                      <Edit size={16} />
-                    </Button>
-                    <Button variant="subtle" size="compact-sm" color="red" onClick={() => onDelete(value.id)}>
-                      <Trash2 size={16} />
-                    </Button>
+                    <Group gap="xs" wrap="nowrap" justify="flex-end">
+                      <Button variant="subtle" size="compact-xs" onClick={() => handleEdit(value)}>
+                        <Edit size={12} />
+                      </Button>
+                      <Button variant="subtle" size="compact-xs" color="red" onClick={() => onDelete(value.id)}>
+                        <Trash2 size={12} />
+                      </Button>
+                    </Group>
                   </Table.Td>
                 </Table.Tr>
               ))}
@@ -99,10 +103,10 @@ export default function ValueTable({ investmentId, values, onDelete }: ValueTabl
           </Table>
         ) : (
           <Center p="md">
-            <Text c="dimmed">No values recorded yet</Text>
+            <Text c="dimmed" size="sm">No values recorded yet</Text>
           </Center>
         )}
-      </Card.Section>
+      </Stack>
     </Card>
   )
 }

--- a/src/components/ytd-overview.tsx
+++ b/src/components/ytd-overview.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { useMemo } from 'react'
-import { Calendar, CreditCard, DollarSign, PiggyBank, TrendingUp, Wallet, BarChart2 } from 'lucide-react'
-import { SimpleGrid, Title, Stack, Group, Text } from '@mantine/core'
-import { OverviewCard } from '@/components/overview-card'
+import { Calendar } from 'lucide-react'
+import { Card, Title, Stack, Group, Text } from '@mantine/core'
 import { useCategoryStore, useExpenseStore, useIncomeStore } from '@/stores/instantdb'
 import { useInvestmentStore } from '@/stores/useInvestmentStore'
 
@@ -20,11 +19,7 @@ const percentFormatter = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 1
 })
 
-interface YTDOverviewProps {
-  compact?: boolean
-}
-
-export function YTDOverview({ compact = false }: YTDOverviewProps) {
+export function YTDOverview() {
   const currentDate = new Date()
   const currentYear = currentDate.getFullYear()
   const currentMonth = currentDate.getMonth() // 0-indexed
@@ -135,64 +130,22 @@ export function YTDOverview({ compact = false }: YTDOverviewProps) {
     { label: 'Savings Rate', value: formatPercent(ytdData.ytdSavingsRate) }
   ]
 
-  // Compact view: key-value pairs without card wrapper (for mobile accordion)
-  if (compact) {
-    return (
-      <Stack gap="xs">
-        {metrics.map((metric) => (
-          <Group key={metric.label} justify="space-between">
-            <Text size="sm" c="dimmed">{metric.label}</Text>
-            <Text size="sm" fw={600} className="numeric-value">{metric.value}</Text>
-          </Group>
-        ))}
-      </Stack>
-    )
-  }
-
-  // Full view: cards with icons (for desktop)
   return (
-    <Stack gap="sm">
-      <Title order={4} c="dimmed">
-        <Calendar size={16} style={{ display: 'inline', marginRight: 8, verticalAlign: 'middle' }} />
-        Year to Date ({currentYear})
-      </Title>
-      <SimpleGrid cols={{ base: 2, xs: 2, sm: 3, md: 4, lg: 7 }} spacing="md">
-        <OverviewCard
-          title="YTD Budget"
-          value={formatCurrency(ytdData.ytdBudget)}
-          icon={<Wallet size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
-        />
-        <OverviewCard
-          title="YTD Spent"
-          value={formatCurrency(ytdData.ytdSpent)}
-          icon={<CreditCard size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
-        />
-        <OverviewCard
-          title="YTD Income"
-          value={formatCurrency(ytdData.ytdIncome)}
-          icon={<DollarSign size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
-        />
-        <OverviewCard
-          title="Total Invested"
-          value={formatCurrency(ytdData.totalInvested)}
-          icon={<PiggyBank size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
-        />
-        <OverviewCard
-          title="Investment Value"
-          value={formatCurrency(ytdData.totalInvestmentValue)}
-          icon={<TrendingUp size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
-        />
-        <OverviewCard
-          title="YTD Savings"
-          value={formatCurrency(ytdData.ytdSavings)}
-          icon={<PiggyBank size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
-        />
-        <OverviewCard
-          title="Savings Rate"
-          value={formatPercent(ytdData.ytdSavingsRate)}
-          icon={<BarChart2 size={16} style={{ color: 'var(--mantine-color-dimmed)' }} />}
-        />
-      </SimpleGrid>
-    </Stack>
+    <Card shadow="sm" padding="md" radius="md" withBorder>
+      <Stack gap="md">
+        <Group gap="xs">
+          <Calendar size={18} style={{ color: 'var(--mantine-color-dimmed)' }} />
+          <Title order={4} c="dimmed">Year to Date ({currentYear})</Title>
+        </Group>
+        <Stack gap="xs">
+          {metrics.map((metric) => (
+            <Group key={metric.label} justify="space-between">
+              <Text size="sm" c="dimmed">{metric.label}</Text>
+              <Text size="sm" fw={600} className="numeric-value">{metric.value}</Text>
+            </Group>
+          ))}
+        </Stack>
+      </Stack>
+    </Card>
   )
 }

--- a/src/routes/accounts-page.tsx
+++ b/src/routes/accounts-page.tsx
@@ -6,6 +6,14 @@ import { AccountForm } from '@/components/account-form'
 import { AccountList } from '@/components/account-list'
 import { Button, Card, Modal, Stack, SimpleGrid, Group, Text, Title } from '@mantine/core'
 import { useSharedQueryParams } from '@/hooks/use-shared-query-params'
+import { Calculator, Wallet } from 'lucide-react'
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
+})
 
 const getPreviousMonthYear = (year: number, month: number) => {
   if (month === 0) {
@@ -61,58 +69,52 @@ export default function AccountsPage() {
   const realAccountsTotal = currentMonthBalance
   const discrepancy = realAccountsTotal - expectedAccountsTotal
 
-  return (
-    <Stack gap="xl">
+  const summaryMetrics = [
+    { label: 'Total Account Balances', value: currencyFormatter.format(currentMonthBalance) },
+    { label: 'Total Expenses', value: currencyFormatter.format(currentMonthExpenses) },
+    { label: 'Total Income', value: currencyFormatter.format(currentMonthIncome) },
+    { label: 'Expected Accounts Total', value: currencyFormatter.format(expectedAccountsTotal) },
+    { label: 'Real Accounts Total', value: currencyFormatter.format(realAccountsTotal) },
+    { label: 'Discrepancy', value: currencyFormatter.format(discrepancy), color: discrepancy >= 0 ? 'green.6' : 'red.6' }
+  ]
 
-      <SimpleGrid cols={{ base: 1, md: 2 }} spacing="xl">
-        <Card shadow="sm" padding="0" radius="md" withBorder>
-          <Card.Section withBorder inheritPadding py="xs" bg="gray.0">
-            <Title order={3} size="h5">Summary</Title>
-          </Card.Section>
-          <Card.Section inheritPadding py="md">
-            <Stack gap="sm">
-              <Group justify="space-between">
-                <Text c="dimmed">Total Account Balances</Text>
-                <Text>${currentMonthBalance.toFixed(2)}</Text>
-              </Group>
-              <Group justify="space-between">
-                <Text c="dimmed">Total Expenses</Text>
-                <Text>${currentMonthExpenses.toFixed(2)}</Text>
-              </Group>
-              <Group justify="space-between">
-                <Text c="dimmed">Total Income</Text>
-                <Text>${currentMonthIncome.toFixed(2)}</Text>
-              </Group>
-              <Group justify="space-between">
-                <Text c="dimmed">Expected Accounts Total</Text>
-                <Text>${expectedAccountsTotal.toFixed(2)}</Text>
-              </Group>
-              <Group justify="space-between">
-                <Text c="dimmed">Real Accounts Total</Text>
-                <Text>${realAccountsTotal.toFixed(2)}</Text>
-              </Group>
-            </Stack>
-          </Card.Section>
-          <Card.Section withBorder inheritPadding py="xs" bg="gray.0">
-            <Group justify="space-between">
-              <Text c="dimmed">Discrepancy</Text>
-              <Text fw={600} c={discrepancy > 0 ? 'green.6' : 'red.6'}>
-                ${discrepancy.toFixed(2)}
-              </Text>
+  return (
+    <Stack gap="lg">
+      <SimpleGrid cols={{ base: 1, md: 2 }} spacing="lg">
+        {/* Summary Card - matches YTD style */}
+        <Card shadow="sm" padding="md" radius="md" withBorder>
+          <Stack gap="md">
+            <Group gap="xs">
+              <Calculator size={18} style={{ color: 'var(--mantine-color-dimmed)' }} />
+              <Title order={4} c="dimmed">Summary</Title>
             </Group>
-          </Card.Section>
+            <Stack gap="xs">
+              {summaryMetrics.map((metric) => (
+                <Group key={metric.label} justify="space-between">
+                  <Text size="sm" c="dimmed">{metric.label}</Text>
+                  <Text size="sm" fw={600} className="numeric-value" c={metric.color}>
+                    {metric.value}
+                  </Text>
+                </Group>
+              ))}
+            </Stack>
+          </Stack>
         </Card>
 
-        <Card shadow="sm" padding="0" radius="md" withBorder>
-          <Card.Section withBorder inheritPadding py="xs" bg="gray.0">
-            <Group justify="space-between">
-              <Title order={3} size="h5">Account Balances</Title>
-              <Button size="sm" onClick={() => setIsAddAccountDialogOpen(true)}>
+        {/* Account Balances Card - matches YTD style */}
+        <Card shadow="sm" padding="md" radius="md" withBorder>
+          <Stack gap="md">
+            <Group gap="xs" justify="space-between">
+              <Group gap="xs">
+                <Wallet size={18} style={{ color: 'var(--mantine-color-dimmed)' }} />
+                <Title order={4} c="dimmed">Account Balances</Title>
+              </Group>
+              <Button size="xs" onClick={() => setIsAddAccountDialogOpen(true)}>
                 Add
               </Button>
             </Group>
-          </Card.Section>
-          <AccountList selectedYear={selectedYear} selectedMonth={selectedMonth} />
+            <AccountList selectedYear={selectedYear} selectedMonth={selectedMonth} />
+          </Stack>
         </Card>
       </SimpleGrid>
 

--- a/src/routes/home-page.tsx
+++ b/src/routes/home-page.tsx
@@ -8,9 +8,9 @@ import { HomeOverview } from '@/components/home-overview'
 import { IncomeOverview } from '@/components/income-overview'
 import { InvestmentOverview } from '@/components/investment/investment-overview'
 import { YTDOverview } from '@/components/ytd-overview'
-import { PageHeader } from '@/components/page-header'
 import { useSharedQueryParams } from '@/hooks/use-shared-query-params'
-import { Stack, Accordion, Box, Card } from '@mantine/core'
+import { Stack, Card, SimpleGrid } from '@mantine/core'
+import { Accordion } from '@mantine/core'
 
 export default function HomePage() {
   const { selectedYear, selectedMonth } = useSharedQueryParams()
@@ -46,57 +46,21 @@ export default function HomePage() {
 
   return (
     <Stack gap="lg">
-      {/* YTD Overview - Desktop: always visible */}
-      <Box visibleFrom="sm">
+      {/* YTD and Monthly Overview side by side on desktop, stacked on mobile */}
+      <SimpleGrid cols={{ base: 1, md: 2 }} spacing="lg">
         <YTDOverview />
-      </Box>
+        <HomeOverview
+          totalMonthlyIncomes={totalMonthlyIncomes}
+          totalMonthlyExpenses={totalMonthlyExpenses}
+          netIncome={netIncome}
+          totalInvestmentValue={totalInvestmentValue}
+        />
+      </SimpleGrid>
 
-      {/* YTD Overview - Mobile: collapsible inside a card */}
-      <Box hiddenFrom="sm">
-        <Card shadow="sm" padding={0} radius="md" withBorder>
-          <Accordion>
-            <Accordion.Item value="ytd" style={{ border: 'none' }}>
-              <Accordion.Control>Year to Date Overview</Accordion.Control>
-              <Accordion.Panel>
-                <YTDOverview compact />
-              </Accordion.Panel>
-            </Accordion.Item>
-          </Accordion>
-        </Card>
-      </Box>
-
-      <HomeOverview
-        totalMonthlyIncomes={totalMonthlyIncomes}
-        totalMonthlyExpenses={totalMonthlyExpenses}
-        netIncome={netIncome}
-        totalInvestmentValue={totalInvestmentValue}
-      />
-
-      {/* Mobile view - regular stack */}
-      <Box hiddenFrom="sm">
-        <Stack gap="lg">
-          <ExpenseOverview
-            expenses={expenses}
-            expenseCategories={expenseCategories}
-            selectedYear={selectedYear}
-            selectedMonth={selectedMonth}
-          />
-
-          <IncomeOverview
-            incomes={incomes}
-            incomeCategories={incomeCategories}
-            selectedYear={selectedYear}
-            selectedMonth={selectedMonth}
-          />
-
-          <InvestmentOverview />
-        </Stack>
-      </Box>
-
-      {/* Desktop view - accordion for detailed sections */}
-      <Box visibleFrom="sm">
-        <Accordion multiple defaultValue={['expenses', 'incomes', 'investments']}>
-          <Accordion.Item value="expenses">
+      {/* Expense Categories in Card with Accordion */}
+      <Card shadow="sm" padding={0} radius="md" withBorder>
+        <Accordion defaultValue="expenses">
+          <Accordion.Item value="expenses" style={{ border: 'none' }}>
             <Accordion.Control>Expense Categories</Accordion.Control>
             <Accordion.Panel>
               <ExpenseOverview
@@ -107,8 +71,13 @@ export default function HomePage() {
               />
             </Accordion.Panel>
           </Accordion.Item>
+        </Accordion>
+      </Card>
 
-          <Accordion.Item value="incomes">
+      {/* Income Categories in Card with Accordion */}
+      <Card shadow="sm" padding={0} radius="md" withBorder>
+        <Accordion defaultValue="incomes">
+          <Accordion.Item value="incomes" style={{ border: 'none' }}>
             <Accordion.Control>Income Categories</Accordion.Control>
             <Accordion.Panel>
               <IncomeOverview
@@ -119,15 +88,20 @@ export default function HomePage() {
               />
             </Accordion.Panel>
           </Accordion.Item>
+        </Accordion>
+      </Card>
 
-          <Accordion.Item value="investments">
+      {/* Investments in Card with Accordion */}
+      <Card shadow="sm" padding={0} radius="md" withBorder>
+        <Accordion defaultValue="investments">
+          <Accordion.Item value="investments" style={{ border: 'none' }}>
             <Accordion.Control>Investments</Accordion.Control>
             <Accordion.Panel>
               <InvestmentOverview />
             </Accordion.Panel>
           </Accordion.Item>
         </Accordion>
-      </Box>
+      </Card>
     </Stack>
   )
 }

--- a/src/routes/incomes-page.tsx
+++ b/src/routes/incomes-page.tsx
@@ -3,32 +3,23 @@
 import React from 'react'
 import { IncomeForm } from '@/components/income-form'
 import { IncomeList } from '@/components/income-list'
-import { Card, Stack, SimpleGrid, Title } from '@mantine/core'
+import { Card, SimpleGrid } from '@mantine/core'
 import { useSharedQueryParams } from '@/hooks/use-shared-query-params'
 
 export default function IncomesPage() {
   const { selectedYear, selectedMonth } = useSharedQueryParams()
 
   return (
-    <Stack gap="xl">
-      <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
-        <Card shadow="sm" padding="lg" radius="md" withBorder>
-          <Card.Section withBorder inheritPadding py="md">
-            <Title order={2} size="h4">Add Income</Title>
-          </Card.Section>
-          <Card.Section inheritPadding py="md">
-            <IncomeForm selectedYear={selectedYear} selectedMonth={selectedMonth} />
-          </Card.Section>
-        </Card>
-        <Card shadow="sm" padding="lg" radius="md" withBorder>
-          <Card.Section withBorder inheritPadding py="md">
-            <Title order={2} size="h4">Income List</Title>
-          </Card.Section>
-          <Card.Section inheritPadding py="md">
-            <IncomeList selectedYear={selectedYear} selectedMonth={selectedMonth} />
-          </Card.Section>
-        </Card>
-      </SimpleGrid>
-    </Stack>
+    <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
+      {/* Left Panel - Add Income Form */}
+      <Card withBorder p="lg">
+        <IncomeForm selectedYear={selectedYear} selectedMonth={selectedMonth} />
+      </Card>
+
+      {/* Right Panel - Income List */}
+      <Card withBorder p="lg">
+        <IncomeList selectedYear={selectedYear} selectedMonth={selectedMonth} />
+      </Card>
+    </SimpleGrid>
   )
 }

--- a/src/routes/settings-page.tsx
+++ b/src/routes/settings-page.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import { useCategoryStore } from '@/stores/instantdb'
-import { CategoryManager } from '@/components/category-manager'
+import { CategorySpreadsheet } from '@/components/category-spreadsheet'
 import { Stack } from '@mantine/core'
 
 export default function SettingsPage() {
@@ -17,24 +17,21 @@ export default function SettingsPage() {
   } = useCategoryStore()
 
   return (
-    <>
-      <Stack gap="xl">
-        <CategoryManager
-          type="expense"
-          categories={expenseCategories}
-          onAdd={addExpenseCategory}
-          onUpdate={updateExpenseCategory}
-          onDelete={removeExpenseCategory}
-        />
-        <CategoryManager
-          type="income"
-          categories={incomeCategories}
-          onAdd={addIncomeCategory}
-          onUpdate={updateIncomeCategory}
-          onDelete={removeIncomeCategory}
-        />
-        {/* <BackupRestore /> */}
-      </Stack>
-    </>
+    <Stack gap="xl">
+      <CategorySpreadsheet
+        type="expense"
+        categories={expenseCategories}
+        onAdd={addExpenseCategory}
+        onUpdate={updateExpenseCategory}
+        onDelete={removeExpenseCategory}
+      />
+      <CategorySpreadsheet
+        type="income"
+        categories={incomeCategories}
+        onAdd={addIncomeCategory}
+        onUpdate={updateIncomeCategory}
+        onDelete={removeIncomeCategory}
+      />
+    </Stack>
   )
 }


### PR DESCRIPTION
- Convert YTD overview to single card with key-value pairs (50% width on desktop)
- Convert Monthly overview to single card with key-value pairs (50% width on desktop)
- Remove duplicate titles/descriptions from Expense and Income Categories
- Merge Investment Overview cards and remove duplicate headers
- Wrap accordion sections in cards for visual consistency
- Stack YTD and Monthly cards on narrower devices