### PR TITLE
claude/add-reimbursement-categories-JvDA3

### DIFF
--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -28,10 +28,15 @@ export const ExpenseForm: React.FC<ExpenseFormProps> = ({ selectedYear, selected
     return new Date(year, month, 15)
   }
 
-  const addExpenses = (expenses: Expense[]) => {
+  const addExpenses = (expenses: Expense[], allowNegative: boolean = false) => {
     let hasError = false
     expenses.forEach((expense) => {
-      if (!expense.amount || isNaN(Number(expense.amount)) || Number(expense.amount) <= 0) {
+      const amount = Number(expense.amount)
+      const isValidAmount = allowNegative
+        ? !isNaN(amount) && amount !== 0
+        : !isNaN(amount) && amount > 0
+
+      if (!isValidAmount) {
         console.error('Expense validation error: Invalid amount', expense.description, expense.amount)
         setErrors((previousErrors) => [...previousErrors, `Invalid amount for expense: ${expense.description}`])
         hasError = true
@@ -76,7 +81,7 @@ export const ExpenseForm: React.FC<ExpenseFormProps> = ({ selectedYear, selected
   }
 
   const handleAddExpenses = () => {
-    addExpenses(expenses)
+    addExpenses(expenses, true) // Allow negative amounts for manual entry (reimbursements)
   }
 
   const handleInputChange = (index: number, field: keyof Expense, value: string | number | Date) => {

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -28,13 +28,13 @@ export const ExpenseForm: React.FC<ExpenseFormProps> = ({ selectedYear, selected
     return new Date(year, month, 15)
   }
 
-  const addExpenses = (expenses: Expense[], allowNegative: boolean = false) => {
+  const addExpenses = (expenses: Expense[]) => {
     let hasError = false
     expenses.forEach((expense) => {
       const amount = Number(expense.amount)
-      const isValidAmount = allowNegative
-        ? !isNaN(amount) && amount !== 0
-        : !isNaN(amount) && amount > 0
+      // Allow negative amounts for reimbursements, but not zero
+      // AI converter already blocks negatives via Zod schema in the API
+      const isValidAmount = !isNaN(amount) && amount !== 0
 
       if (!isValidAmount) {
         console.error('Expense validation error: Invalid amount', expense.description, expense.amount)
@@ -81,7 +81,7 @@ export const ExpenseForm: React.FC<ExpenseFormProps> = ({ selectedYear, selected
   }
 
   const handleAddExpenses = () => {
-    addExpenses(expenses, true) // Allow negative amounts for manual entry (reimbursements)
+    addExpenses(expenses)
   }
 
   const handleInputChange = (index: number, field: keyof Expense, value: string | number | Date) => {

--- a/src/components/expense-list.tsx
+++ b/src/components/expense-list.tsx
@@ -124,7 +124,9 @@ export const ExpenseList: React.FC<ExpenseListProps> = ({ selectedMonth, selecte
                     <Table.Td>{format(new Date(expense.date), 'dd MMM yyyy')}</Table.Td>
                     <Table.Td>{expense.description}</Table.Td>
                     <Table.Td c="dimmed">{expense.category}</Table.Td>
-                    <Table.Td ta="right" className="numeric-value">${Number(expense.amount).toFixed(2)}</Table.Td>
+                    <Table.Td ta="right" className="numeric-value" c={expense.amount < 0 ? 'green.6' : undefined}>
+                      ${Number(expense.amount).toFixed(2)}
+                    </Table.Td>
                     <Table.Td>
                       <Group gap={4} wrap="nowrap">
                         <Button size="compact-xs" variant="subtle" color="gray" onClick={() => setEditingExpense(expense)}>

--- a/src/components/expense-spreadsheet.tsx
+++ b/src/components/expense-spreadsheet.tsx
@@ -67,6 +67,36 @@ export const ExpenseSpreadsheet: React.FC<ExpenseSpreadsheetProps> = ({
     }))
   }, [expenses, categoryIdToName])
 
+  // Custom renderer for amount column (green for negative/reimbursements)
+  const amountRenderer = useCallback(
+    (
+      instance: Handsontable,
+      td: HTMLTableCellElement,
+      row: number,
+      col: number,
+      prop: string | number,
+      value: any,
+      cellProperties: Handsontable.CellProperties
+    ) => {
+      const numValue = Number(value)
+      const formattedValue = !isNaN(numValue) ? numValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : value
+
+      td.innerHTML = formattedValue
+      td.style.textAlign = 'right'
+
+      if (!isNaN(numValue) && numValue < 0) {
+        td.style.color = 'var(--mantine-color-green-6)'
+        td.style.fontWeight = '500'
+      } else {
+        td.style.color = ''
+        td.style.fontWeight = ''
+      }
+
+      return td
+    },
+    []
+  )
+
   // Custom renderer for delete button
   const deleteButtonRenderer = useCallback(
     (
@@ -197,11 +227,9 @@ export const ExpenseSpreadsheet: React.FC<ExpenseSpreadsheetProps> = ({
         data: 'amount',
         title: 'Amount',
         type: 'numeric',
-        numericFormat: {
-          pattern: '0,0.00'
-        },
         width: 80,
-        className: 'htMiddle htRight'
+        className: 'htMiddle htRight',
+        renderer: amountRenderer
       },
       {
         data: 'id',
@@ -212,7 +240,7 @@ export const ExpenseSpreadsheet: React.FC<ExpenseSpreadsheetProps> = ({
         renderer: deleteButtonRenderer
       }
     ],
-    [categoryNames, deleteButtonRenderer]
+    [categoryNames, deleteButtonRenderer, amountRenderer]
   )
 
   return (

--- a/src/components/expense-table.tsx
+++ b/src/components/expense-table.tsx
@@ -69,6 +69,7 @@ export const ExpenseTable: React.FC<ExpenseTableProps> = ({
                     value={expense.amount}
                     onChange={(value) => onInputChange(index, 'amount', Number(value))}
                     decimalScale={2}
+                    allowNegative
                     required
                     styles={{ input: { borderRadius: 0, padding: '8px' } }}
                   />

--- a/src/components/expense-table.tsx
+++ b/src/components/expense-table.tsx
@@ -69,7 +69,6 @@ export const ExpenseTable: React.FC<ExpenseTableProps> = ({
                     value={expense.amount}
                     onChange={(value) => onInputChange(index, 'amount', Number(value))}
                     decimalScale={2}
-                    min={0}
                     required
                     styles={{ input: { borderRadius: 0, padding: '8px' } }}
                   />

--- a/src/routes/expenses-page.tsx
+++ b/src/routes/expenses-page.tsx
@@ -30,7 +30,10 @@ export default function ExpensesPage() {
     const errors: string[] = []
 
     expenses.forEach((expense) => {
-      if (!expense.amount || isNaN(Number(expense.amount)) || Number(expense.amount) <= 0) {
+      const amount = Number(expense.amount)
+      // Allow negative amounts for reimbursements, but not zero
+      // AI converter already blocks negatives via Zod schema in the API
+      if (isNaN(amount) || amount === 0) {
         errors.push(`Invalid amount for expense: ${expense.description}`)
         hasError = true
         return


### PR DESCRIPTION
- Allow negative amounts in manual expense entry (Table Entry tab)
- Keep AI converter blocking negative amounts via Zod schema
- Display negative amounts in green color in expense list and spreadsheet
- All calculations (home dashboard, YTD, CSV export, accounts) naturally handle negatives