### PR TITLE
claude/add-duplicate-checker-CCslK

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -145,6 +145,11 @@ textarea {
   border: 1px solid #fa5252 !important;
 }
 
+/* Duplicate row highlight - potential duplicate expenses */
+.expense-spreadsheet .duplicate-row {
+  background-color: #fee2e2 !important;
+}
+
 /* Read-only cells */
 .expense-spreadsheet .htDimmed,
 .category-spreadsheet .htDimmed {

--- a/src/components/expense-spreadsheet.tsx
+++ b/src/components/expense-spreadsheet.tsx
@@ -21,13 +21,15 @@ interface ExpenseSpreadsheetProps {
     value: string | number | Date
   ) => void
   onDeleteRow: (id: string) => void
+  duplicateIds?: Set<string>
 }
 
 export const ExpenseSpreadsheet: React.FC<ExpenseSpreadsheetProps> = ({
   expenses,
   expenseCategories,
   onInputChange,
-  onDeleteRow
+  onDeleteRow,
+  duplicateIds
 }) => {
 
   // Create category lookup maps
@@ -193,6 +195,20 @@ export const ExpenseSpreadsheet: React.FC<ExpenseSpreadsheetProps> = ({
     [expenses, onInputChange, categoryNameToId]
   )
 
+  // Cell properties callback for duplicate row highlighting
+  const getCellProperties = useCallback(
+    (row: number, col: number): Handsontable.CellMeta => {
+      const expense = expenses[row]
+      if (expense && duplicateIds?.has(expense.id)) {
+        return {
+          className: 'duplicate-row'
+        }
+      }
+      return {}
+    },
+    [expenses, duplicateIds]
+  )
+
   // Column definitions
   const columns: Handsontable.ColumnSettings[] = useMemo(
     () => [
@@ -267,6 +283,7 @@ export const ExpenseSpreadsheet: React.FC<ExpenseSpreadsheetProps> = ({
           manualColumnResize={true}
           className="expense-spreadsheet"
           afterChange={handleAfterChange}
+          cells={getCellProperties}
           // Styling
           customBorders={false}
           outsideClickDeselects={false}


### PR DESCRIPTION
Highlights AI-generated expenses with light red background when they match existing expenses in the same month (same date + amount). This helps users identify potentially duplicated transactions before saving.