### PR TITLE
Add unsaved changes warning for forms

### DIFF
--- a/src/components/income-form.tsx
+++ b/src/components/income-form.tsx
@@ -3,6 +3,7 @@ import { useCategoryStore, useIncomeStore } from '@/stores/instantdb'
 import { Button, NumberInput, Group, Stack } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
 import { IncomeSpreadsheet } from '@/components/income-spreadsheet'
+import { useUnsavedChangesWarning } from '@/hooks/use-unsaved-changes-warning'
 
 interface IncomeFormProps {
   selectedYear: number
@@ -25,6 +26,8 @@ export const IncomeForm: React.FC<IncomeFormProps> = ({ selectedYear, selectedMo
   const [rowsToAdd, setRowsToAdd] = useState(1)
   const { addIncome } = useIncomeStore()
   const { data: { incomeCategories = [] } = {} } = useCategoryStore()
+  const isDirty = tableIncomes.some((i) => i.amount !== '' || i.description !== '')
+  useUnsavedChangesWarning(isDirty)
 
   function getDefaultDate(year: number, month: number): Date {
     const currentDate = new Date()

--- a/src/components/pages/expenses-page.tsx
+++ b/src/components/pages/expenses-page.tsx
@@ -8,11 +8,13 @@ import { ExpenseSpreadsheet } from '@/components/expense-spreadsheet'
 import { Expense, useCategoryStore, useExpenseStore } from '@/stores/instantdb'
 import { notifications } from '@mantine/notifications'
 import { SparklesIcon, TableIcon, UploadIcon } from 'lucide-react'
+import { useUnsavedChangesWarning } from '@/hooks/use-unsaved-changes-warning'
 
 export default function ExpensesPage() {
   const { selectedYear, selectedMonth } = useSharedQueryParams()
   const [expenses, setExpenses] = useState<Expense[]>([])
   const [rowsToAdd, setRowsToAdd] = useState(1)
+  useUnsavedChangesWarning(expenses.length > 0)
   const [activeTab, setActiveTab] = useState('upload')
   const { addExpense } = useExpenseStore()
   const { data: { expenseCategories = [] } = {} } = useCategoryStore()

--- a/src/hooks/use-unsaved-changes-warning.ts
+++ b/src/hooks/use-unsaved-changes-warning.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+import { useBlocker } from '@tanstack/react-router'
+
+export function useUnsavedChangesWarning(isDirty: boolean) {
+  useBlocker(
+    () => !window.confirm('You have unsaved changes. Are you sure you want to leave?'),
+    isDirty
+  )
+
+  useEffect(() => {
+    if (!isDirty) return
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [isDirty])
+}


### PR DESCRIPTION
## Summary
This PR adds a warning dialog to prevent users from accidentally losing unsaved changes when navigating away from forms or closing the browser tab.

## Key Changes
- **New hook**: Created `useUnsavedChangesWarning` hook that:
  - Uses `@tanstack/react-router`'s `useBlocker` to intercept navigation when there are unsaved changes
  - Shows a confirmation dialog before allowing navigation away
  - Listens to the `beforeunload` event to warn users when closing the browser tab or window
  
- **IncomeForm**: Integrated unsaved changes detection by tracking if any income rows have data (non-empty amount or description)

- **ExpensesPage**: Integrated unsaved changes detection by checking if there are any expenses in the local state

## Implementation Details
- The hook accepts an `isDirty` boolean flag to determine when to show warnings
- Navigation blocking uses a confirmation dialog: "You have unsaved changes. Are you sure you want to leave?"
- Browser tab/window closing is handled via the `beforeunload` event listener
- The `beforeunload` listener is properly cleaned up when the component unmounts or when `isDirty` becomes false

https://claude.ai/code/session_019exEiasCDyRpwfeAonij8L