### PR TITLE
Fix budget handling for expense categories with zero values

### DIFF
--- a/src/components/category-manager.tsx
+++ b/src/components/category-manager.tsx
@@ -170,9 +170,15 @@ export const CategoryManager: React.FC<CategoryManagerProps> = ({ type, categori
     try {
       if (category.isNew) {
         const { id: _id, isNew: _isNew, ...newCategory } = category
+        if (isExpenseCategory(category) && (newCategory as Partial<ExpenseCategory>).maxAnnualBudget === 0) {
+          delete (newCategory as Partial<ExpenseCategory>).maxAnnualBudget
+        }
         await onAdd(newCategory)
       } else if (category.id) {
         const { id: _id, isNew: _isNew, ...updateData } = category
+        if (isExpenseCategory(category) && (updateData as Partial<ExpenseCategory>).maxAnnualBudget === 0) {
+          delete (updateData as Partial<ExpenseCategory>).maxAnnualBudget
+        }
         await onUpdate(category.id, updateData)
       }
     } catch (error) {

--- a/src/components/expense-overview.tsx
+++ b/src/components/expense-overview.tsx
@@ -43,7 +43,7 @@ export function ExpenseOverview({ expenses, expenseCategories, selectedYear, sel
 
   const calculateAnnualBudget = useCallback(
     (maxBudget: number | undefined, maxAnnualBudget: number | undefined): number | undefined => {
-      if (maxAnnualBudget !== undefined) return maxAnnualBudget
+      if (maxAnnualBudget) return maxAnnualBudget
       if (maxBudget !== undefined) return maxBudget * 12
       return undefined
     },


### PR DESCRIPTION
## Summary
This PR fixes budget handling for expense categories by properly excluding zero-valued `maxAnnualBudget` fields during save operations and correcting the budget calculation logic to treat zero as falsy.

## Key Changes
- **category-manager.tsx**: Added logic to delete `maxAnnualBudget` property when it equals 0 for both new and updated expense categories, preventing zero values from being persisted
- **expense-overview.tsx**: Changed budget calculation condition from `!== undefined` to truthy check, ensuring zero values are treated as falsy and fall back to the `maxBudget * 12` calculation

## Implementation Details
The changes ensure consistent handling of zero budget values:
- When saving a category with `maxAnnualBudget: 0`, the property is removed from the payload before sending to the backend
- When calculating annual budget, zero values are now properly treated as "not set" and fall back to the monthly budget multiplied by 12
- This prevents zero from being treated as a valid budget value while maintaining backward compatibility with undefined values

https://claude.ai/code/session_01UkpkuKar1J8LdXY8fvUyFW