### PR TITLE
Refactor investment forms to use modals instead of dedicated pages

### DIFF
--- a/src/components/investment/forms/investment-form.tsx
+++ b/src/components/investment/forms/investment-form.tsx
@@ -3,15 +3,16 @@ import { useInvestmentStore } from '@/stores/useInvestmentStore'
 import { Investment } from '@/types/investment'
 import { useForm, Controller } from 'react-hook-form'
 import { useNavigate } from '@tanstack/react-router'
-import { Button, Card, TextInput, Textarea, Switch, Stack, Group, Text, Title } from '@mantine/core'
+import { Button, TextInput, Textarea, Switch, Stack, Group, Text } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
 
 interface InvestmentFormProps {
   investment?: Investment
   onSuccess?: () => void
+  onCancel?: () => void
 }
 
-export default function InvestmentForm({ investment, onSuccess }: InvestmentFormProps) {
+export default function InvestmentForm({ investment, onSuccess, onCancel }: InvestmentFormProps) {
   const navigate = useNavigate()
   const { addInvestment, updateInvestment } = useInvestmentStore()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -64,68 +65,65 @@ export default function InvestmentForm({ investment, onSuccess }: InvestmentForm
   }
 
   return (
-    <Card>
-      <Title order={5} mb="sm">{investment ? 'Edit Investment' : 'Add Investment'}</Title>
-      <form onSubmit={handleSubmit(onSubmit)}>
-        <Stack gap="sm">
-          <Controller
-            name="name"
-            control={control}
-            rules={{ required: 'Name is required' }}
-            render={({ field }) => (
-              <TextInput
-                label="Name"
-                placeholder="Investment name"
-                error={errors.name?.message}
-                {...field}
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Stack gap="sm">
+        <Controller
+          name="name"
+          control={control}
+          rules={{ required: 'Name is required' }}
+          render={({ field }) => (
+            <TextInput
+              label="Name"
+              placeholder="Investment name"
+              error={errors.name?.message}
+              {...field}
+            />
+          )}
+        />
+
+        <Controller
+          name="description"
+          control={control}
+          render={({ field }) => (
+            <Textarea
+              label="Description (optional)"
+              placeholder="Investment description"
+              error={errors.description?.message}
+              {...field}
+            />
+          )}
+        />
+
+        <Controller
+          name="isActive"
+          control={control}
+          render={({ field }) => (
+            <Group
+              justify="space-between"
+              p="xs"
+              style={{ border: '1px solid var(--mantine-color-gray-3)', borderRadius: 'var(--mantine-radius-sm)' }}
+            >
+              <Stack gap={0}>
+                <Text size="sm" fw={500}>Active</Text>
+                <Text size="xs" c="dimmed">Mark this investment as active or inactive</Text>
+              </Stack>
+              <Switch
+                checked={field.value}
+                onChange={field.onChange}
               />
-            )}
-          />
+            </Group>
+          )}
+        />
 
-          <Controller
-            name="description"
-            control={control}
-            render={({ field }) => (
-              <Textarea
-                label="Description (optional)"
-                placeholder="Investment description"
-                error={errors.description?.message}
-                {...field}
-              />
-            )}
-          />
-
-          <Controller
-            name="isActive"
-            control={control}
-            render={({ field }) => (
-              <Group
-                justify="space-between"
-                p="xs"
-                style={{ border: '1px solid var(--mantine-color-gray-3)', borderRadius: 'var(--mantine-radius-sm)' }}
-              >
-                <Stack gap={0}>
-                  <Text size="sm" fw={500}>Active</Text>
-                  <Text size="xs" c="dimmed">Mark this investment as active or inactive</Text>
-                </Stack>
-                <Switch
-                  checked={field.value}
-                  onChange={field.onChange}
-                />
-              </Group>
-            )}
-          />
-
-          <Group justify="space-between" mt="xs">
-            <Button variant="subtle" color="gray" onClick={() => navigate({ to: '/investments' })}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={isSubmitting}>
-              {investment ? 'Update' : 'Create'}
-            </Button>
-          </Group>
-        </Stack>
-      </form>
-    </Card>
+        <Group justify="flex-end" gap="xs" mt="xs">
+          <Button variant="subtle" color="gray" onClick={onCancel ?? (() => navigate({ to: '/investments' }))}>
+            Cancel
+          </Button>
+          <Button type="submit" loading={isSubmitting}>
+            {investment ? 'Update' : 'Create'}
+          </Button>
+        </Group>
+      </Stack>
+    </form>
   )
 }

--- a/src/components/pages/edit-investment-page.tsx
+++ b/src/components/pages/edit-investment-page.tsx
@@ -4,7 +4,7 @@ import { Link, useNavigate } from '@tanstack/react-router'
 import { Route } from '@/routes/investments.$id.edit'
 import InvestmentForm from '@/components/investment/forms/investment-form'
 import { PageHeader } from '@/components/page-header'
-import { Button, Stack, Title, Text, Center } from '@mantine/core'
+import { Button, Card, Stack, Title, Text, Center } from '@mantine/core'
 
 export default function EditInvestmentPage() {
   const { id } = Route.useParams()
@@ -37,7 +37,9 @@ export default function EditInvestmentPage() {
 
       <PageHeader title="Edit Investment" description="Update your investment details" />
 
-      <InvestmentForm investment={investment} onSuccess={() => navigate({ to: '/investments/$id', params: { id } })} />
+      <Card>
+        <InvestmentForm investment={investment} onSuccess={() => navigate({ to: '/investments/$id', params: { id } })} />
+      </Card>
     </Stack>
   )
 }

--- a/src/components/pages/investment-detail-page.tsx
+++ b/src/components/pages/investment-detail-page.tsx
@@ -6,6 +6,7 @@ import { Route } from '@/routes/investments.$id'
 import ContributionTable from '@/components/investment/contribution-table'
 import PerformanceGraph from '@/components/investment/performance-graph'
 import ValueTable from '@/components/investment/value-table'
+import InvestmentForm from '@/components/investment/forms/investment-form'
 import { Button, Card, Modal, Stack, Group, Title, Text, SimpleGrid, Center } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
 
@@ -30,6 +31,7 @@ export default function InvestmentDetailPage() {
     deleteValue
   } = useInvestmentStore()
   const [deleteModalOpen, setDeleteModalOpen] = useState(false)
+  const [editModalOpen, setEditModalOpen] = useState(false)
 
   // Find the investment by ID
   const investment = investments.find((inv) => inv.id === id)
@@ -135,7 +137,7 @@ export default function InvestmentDetailPage() {
           Back to Investments
         </Button>
         <Group gap="xs">
-          <Button variant="default" component={Link} to="/investments/$id/edit" params={{ id } as any} leftSection={<Edit size={14} />}>
+          <Button variant="default" onClick={() => setEditModalOpen(true)} leftSection={<Edit size={14} />}>
             Edit
           </Button>
           <Button color="red" onClick={() => setDeleteModalOpen(true)} leftSection={<Trash2 size={14} />}>
@@ -179,6 +181,20 @@ export default function InvestmentDetailPage() {
         <ContributionTable investmentId={id} contributions={contributions} onDelete={handleDeleteContribution} />
         <ValueTable investmentId={id} values={values} onDelete={handleDeleteValue} />
       </SimpleGrid>
+
+      {/* Edit Investment Modal */}
+      <Modal
+        opened={editModalOpen}
+        onClose={() => setEditModalOpen(false)}
+        title="Edit Investment"
+        centered
+      >
+        <InvestmentForm
+          investment={investment}
+          onSuccess={() => setEditModalOpen(false)}
+          onCancel={() => setEditModalOpen(false)}
+        />
+      </Modal>
 
       {/* Delete Confirmation Modal */}
       <Modal

--- a/src/components/pages/investments-page.tsx
+++ b/src/components/pages/investments-page.tsx
@@ -1,27 +1,26 @@
+import { useState } from 'react'
 import { useInvestmentStore } from '@/stores/useInvestmentStore'
 import { Plus } from 'lucide-react'
-import { Link } from '@tanstack/react-router'
 import InvestmentCard from '@/components/investment/investment-card'
+import InvestmentForm from '@/components/investment/forms/investment-form'
 import { useSetHeaderAction } from '@/contexts/header-action-context'
-import { Button, Stack, Title, Text, Card, SimpleGrid, Center, ActionIcon } from '@mantine/core'
+import { Button, Modal, Stack, Title, Text, Card, SimpleGrid, Center, ActionIcon } from '@mantine/core'
 
 export default function InvestmentsPage() {
   const { investments } = useInvestmentStore()
+  const [addModalOpen, setAddModalOpen] = useState(false)
 
-  // Set header action - show label on desktop, icon only on mobile
   useSetHeaderAction(
     <>
       <Button
-        component={Link}
-        to="/investments/new"
+        onClick={() => setAddModalOpen(true)}
         leftSection={<Plus size={16} />}
         visibleFrom="sm"
       >
         Add Investment
       </Button>
       <ActionIcon
-        component={Link}
-        to="/investments/new"
+        onClick={() => setAddModalOpen(true)}
         variant="filled"
         hiddenFrom="sm"
         size="lg"
@@ -40,7 +39,7 @@ export default function InvestmentsPage() {
             <Stack align="center" gap="sm">
               <Title order={4}>No investments yet</Title>
               <Text size="sm" c="dimmed">Get started by adding your first investment</Text>
-              <Button component={Link} to="/investments/new" leftSection={<Plus size={16} />}>
+              <Button onClick={() => setAddModalOpen(true)} leftSection={<Plus size={16} />}>
                 Add Investment
               </Button>
             </Stack>
@@ -53,6 +52,18 @@ export default function InvestmentsPage() {
           ))}
         </SimpleGrid>
       )}
+
+      <Modal
+        opened={addModalOpen}
+        onClose={() => setAddModalOpen(false)}
+        title="Add Investment"
+        centered
+      >
+        <InvestmentForm
+          onSuccess={() => setAddModalOpen(false)}
+          onCancel={() => setAddModalOpen(false)}
+        />
+      </Modal>
     </Stack>
   )
 }

--- a/src/components/pages/new-investment-page.tsx
+++ b/src/components/pages/new-investment-page.tsx
@@ -2,7 +2,7 @@ import { ArrowLeft } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import InvestmentForm from '@/components/investment/forms/investment-form'
 import { PageHeader } from '@/components/page-header'
-import { Button, Stack, Group } from '@mantine/core'
+import { Button, Card, Stack, Group } from '@mantine/core'
 
 export default function NewInvestmentPage() {
   return (
@@ -15,7 +15,9 @@ export default function NewInvestmentPage() {
 
       <PageHeader title="Add Investment" description="Create a new investment to track" />
 
-      <InvestmentForm />
+      <Card>
+        <InvestmentForm />
+      </Card>
     </Stack>
   )
 }


### PR DESCRIPTION
## Summary
This PR refactors the investment form UI to use modal dialogs instead of dedicated page routes. The form component is now more flexible and reusable, allowing it to be embedded in modals while maintaining the existing dedicated page routes as fallbacks.

## Key Changes
- **InvestmentForm component**: Removed Card wrapper and Title from the form component itself, making it more composable. Added optional `onCancel` callback prop to allow parent components to handle cancellation (defaults to navigation if not provided).
- **InvestmentsPage**: Replaced route-based "Add Investment" button with a modal dialog that opens the form inline. Removed dependency on `/investments/new` route.
- **InvestmentDetailPage**: Added modal for editing investments directly from the detail view. Replaced route-based Edit button with modal trigger.
- **EditInvestmentPage & NewInvestmentPage**: Wrapped the form component in a Card component since the form no longer includes its own Card wrapper.
- **Removed unused imports**: Cleaned up unused imports like `Card`, `Title` from InvestmentForm and `Link` from InvestmentsPage.

## Implementation Details
- The form now supports both modal and page-based usage patterns through the optional `onCancel` callback
- Modal dialogs are centered and properly titled
- The form maintains all existing validation and submission logic
- Backward compatibility is preserved - the dedicated `/investments/new` and `/investments/$id/edit` routes still work for direct access
- Button layout changed from `space-between` to `flex-end` alignment in the form footer for better UX in modal context

https://claude.ai/code/session_013Kf1gbTLxKTUfq9CcNYdep