### PR TITLE
feat: upgrade export CSV button to dropdown with overview and full options

### DIFF
--- a/src/components/pages/home-page.tsx
+++ b/src/components/pages/home-page.tsx
@@ -9,39 +9,47 @@ import { YTDOverview } from '@/components/ytd-overview'
 import { useSharedQueryParams } from '@/hooks/use-shared-query-params'
 import { useDashboardExport } from '@/hooks/use-dashboard-export'
 import { useSetHeaderAction } from '@/contexts/header-action-context'
-import { Stack, Card, SimpleGrid, Button, ActionIcon } from '@mantine/core'
+import { Stack, Card, SimpleGrid, Button, ActionIcon, Menu } from '@mantine/core'
 import { Accordion } from '@mantine/core'
-import { Download } from 'lucide-react'
+import { Download, ChevronDown } from 'lucide-react'
 
 export default function HomePage() {
   const { selectedYear, selectedMonth } = useSharedQueryParams()
-  const { exportToCSV } = useDashboardExport()
+  const { exportOverviewToCSV, exportFullToCSV } = useDashboardExport()
 
   const { data: { expenseCategories = [], incomeCategories = [] } = {} } = useCategoryStore()
   const { data: { expenses = [] } = {} } = useExpenseStore()
   const { data: { incomes = [] } = {} } = useIncomeStore()
   const { investments, getLatestValue } = useInvestmentStore()
 
-  // Set header action - show label on desktop, icon only on mobile
   useSetHeaderAction(
     <>
-      <Button
-        leftSection={<Download size={16} />}
-        variant="light"
-        onClick={exportToCSV}
-        visibleFrom="sm"
-      >
-        Export CSV
-      </Button>
-      <ActionIcon
-        variant="light"
-        onClick={exportToCSV}
-        hiddenFrom="sm"
-        size="lg"
-        aria-label="Export CSV"
-      >
-        <Download size={18} />
-      </ActionIcon>
+      <Menu shadow="md" width={180} visibleFrom="sm">
+        <Menu.Target>
+          <Button
+            leftSection={<Download size={16} />}
+            rightSection={<ChevronDown size={14} />}
+            variant="light"
+          >
+            Export CSV
+          </Button>
+        </Menu.Target>
+        <Menu.Dropdown>
+          <Menu.Item onClick={exportOverviewToCSV}>Overview</Menu.Item>
+          <Menu.Item onClick={exportFullToCSV}>Full</Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
+      <Menu shadow="md" width={180} hiddenFrom="sm">
+        <Menu.Target>
+          <ActionIcon variant="light" size="lg" aria-label="Export CSV">
+            <Download size={18} />
+          </ActionIcon>
+        </Menu.Target>
+        <Menu.Dropdown>
+          <Menu.Item onClick={exportOverviewToCSV}>Overview</Menu.Item>
+          <Menu.Item onClick={exportFullToCSV}>Full</Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
     </>
   )
 

--- a/src/hooks/use-dashboard-export.ts
+++ b/src/hooks/use-dashboard-export.ts
@@ -324,15 +324,69 @@ export function useDashboardExport() {
     return lines.join('\n')
   }, [ytdData, expenseCategoriesData, incomeCategoriesData, investmentData])
 
-  // Export function
-  const exportToCSV = useCallback(() => {
+  // Build full CSV content (overview + individual transactions for selected month)
+  const buildFullCSVContent = useCallback(() => {
+    const overviewContent = buildCSVContent()
+    const lines: string[] = [overviewContent, '']
+
+    const monthLabel = format(new Date(selectedYear, selectedMonth), 'MMMM yyyy')
+
+    lines.push(`SECTION: All Expenses (${monthLabel})`)
+    lines.push(createCSVRow(['Date', 'Category', 'Description', 'Amount']))
+    const monthExpenses = expenses
+      .filter((expense) => {
+        const d = new Date(expense.date)
+        return d.getFullYear() === selectedYear && d.getMonth() === selectedMonth
+      })
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+    monthExpenses.forEach((expense) => {
+      const categoryName = expenseCategories.find((c) => c.id === expense.categoryId)?.name ?? ''
+      lines.push(createCSVRow([
+        expense.date,
+        escapeCSVField(categoryName),
+        escapeCSVField(expense.description),
+        formatNumberForCSV(expense.amount)
+      ]))
+    })
+    lines.push('')
+
+    lines.push(`SECTION: All Incomes (${monthLabel})`)
+    lines.push(createCSVRow(['Date', 'Category', 'Description', 'Amount']))
+    const monthIncomes = incomes
+      .filter((income) => {
+        const d = new Date(income.date)
+        return d.getFullYear() === selectedYear && d.getMonth() === selectedMonth
+      })
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+    monthIncomes.forEach((income) => {
+      const categoryName = incomeCategories.find((c) => c.id === income.categoryId)?.title ?? ''
+      lines.push(createCSVRow([
+        income.date,
+        escapeCSVField(categoryName),
+        escapeCSVField(income.description),
+        formatNumberForCSV(income.amount)
+      ]))
+    })
+
+    return lines.join('\n')
+  }, [buildCSVContent, expenses, incomes, expenseCategories, incomeCategories, selectedYear, selectedMonth])
+
+  const exportOverviewToCSV = useCallback(() => {
     const csvContent = buildCSVContent()
     const dateForFilename = new Date(selectedYear, selectedMonth)
-    const filename = `Dashboard-${format(dateForFilename, 'MMM-yyyy')}.csv`
+    const filename = `Dashboard-Overview-${format(dateForFilename, 'MMM-yyyy')}.csv`
     downloadCSV(csvContent, filename)
   }, [buildCSVContent, selectedYear, selectedMonth])
 
+  const exportFullToCSV = useCallback(() => {
+    const csvContent = buildFullCSVContent()
+    const dateForFilename = new Date(selectedYear, selectedMonth)
+    const filename = `Dashboard-Full-${format(dateForFilename, 'MMM-yyyy')}.csv`
+    downloadCSV(csvContent, filename)
+  }, [buildFullCSVContent, selectedYear, selectedMonth])
+
   return {
-    exportToCSV
+    exportOverviewToCSV,
+    exportFullToCSV
   }
 }


### PR DESCRIPTION
Adds a Mantine Menu dropdown to the home dashboard header replacing the
single export button. Users can now choose between "Overview" (existing
YTD/category/investment summary) and "Full" (overview + all individual
expenses and incomes for the selected month), making it easy to pass
data to AI for review.

https://claude.ai/code/session_018TLMxK9MwurhoLaVWnkU7j